### PR TITLE
Use criterion for benching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ data-encoding = "2.2.1"
 [dev-dependencies]
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
-bencher = "0.1.5"
+criterion = "0.3.3"
 
 [[bench]]
 name = "bench"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,49 +1,87 @@
 #[macro_use]
-extern crate bencher;
+extern crate criterion;
 
-use bencher::Bencher;
+use criterion::{BenchmarkId, Criterion};
 use sfv::{Parser, SerializeValue};
 
-fn parsing_item(bench: &mut Bencher) {
-    let input = "c29tZXZlcnlsb25nc3RyaW5ndmFsdWVyZXByZXNlbnRlZGFzYnl0ZXNhbnNvbWVvdGhlcmxvbmdsaW5l";
-    bench.iter(|| Parser::parse_item(input.as_bytes()).unwrap());
+criterion_main!(parsing, serializing);
+
+criterion_group!(parsing, parsing_item, parsing_list, parsing_dict);
+
+fn parsing_item(c: &mut Criterion) {
+    let fixture =
+        "c29tZXZlcnlsb25nc3RyaW5ndmFsdWVyZXByZXNlbnRlZGFzYnl0ZXNhbnNvbWVvdGhlcmxvbmdsaW5l";
+    c.bench_with_input(
+        BenchmarkId::new("parsing_item", fixture),
+        &fixture,
+        move |bench, &input| {
+            bench.iter(|| Parser::parse_item(input.as_bytes()).unwrap());
+        },
+    );
 }
 
-fn parsing_list(bench: &mut Bencher) {
-    let input = "a, abcdefghigklmnoprst, 123456785686457, 99999999999.999, (), (\"somelongstringvalue\" \"anotherlongstringvalue\";key=:c29tZXZlciBsb25nc3RyaW5ndmFsdWVyZXByZXNlbnRlZGFzYnl0ZXM: 145)";
-    bench.iter(|| Parser::parse_list(input.as_bytes()).unwrap());
+fn parsing_list(c: &mut Criterion) {
+    let fixture = "a, abcdefghigklmnoprst, 123456785686457, 99999999999.999, (), (\"somelongstringvalue\" \"anotherlongstringvalue\";key=:c29tZXZlciBsb25nc3RyaW5ndmFsdWVyZXByZXNlbnRlZGFzYnl0ZXM: 145)";
+    c.bench_with_input(
+        BenchmarkId::new("parsing_list", fixture),
+        &fixture,
+        move |bench, &input| {
+            bench.iter(|| Parser::parse_list(input.as_bytes()).unwrap());
+        },
+    );
 }
 
-fn parsing_dict(bench: &mut Bencher) {
-    let input = "a, dict_key2=abcdefghigklmnoprst, dict_key3=123456785686457, dict_key4=(\"inner-list-member\" :aW5uZXItbGlzdC1tZW1iZXI=:);key=aW5uZXItbGlzdC1wYXJhbWV0ZXJz";
-    bench.iter(|| Parser::parse_dictionary(input.as_bytes()).unwrap());
+fn parsing_dict(c: &mut Criterion) {
+    let fixture = "a, dict_key2=abcdefghigklmnoprst, dict_key3=123456785686457, dict_key4=(\"inner-list-member\" :aW5uZXItbGlzdC1tZW1iZXI=:);key=aW5uZXItbGlzdC1wYXJhbWV0ZXJz";
+    c.bench_with_input(
+        BenchmarkId::new("parsing_dict", fixture),
+        &fixture,
+        move |bench, &input| {
+            bench.iter(|| Parser::parse_dictionary(input.as_bytes()).unwrap());
+        },
+    );
 }
 
-fn serializing_item(bench: &mut Bencher) {
-    let input = "c29tZXZlcnlsb25nc3RyaW5ndmFsdWVyZXByZXNlbnRlZGFzYnl0ZXNhbnNvbWVvdGhlcmxvbmdsaW5l";
-    let parsed_item = Parser::parse_item(input.as_bytes()).unwrap();
-    bench.iter(|| parsed_item.serialize_value().unwrap());
-}
-
-fn serializing_list(bench: &mut Bencher) {
-    let input = "a, abcdefghigklmnoprst, 123456785686457, 99999999999.999, (), (\"somelongstringvalue\" \"anotherlongstringvalue\";key=:c29tZXZlciBsb25nc3RyaW5ndmFsdWVyZXByZXNlbnRlZGFzYnl0ZXM: 145)";
-    let parsed_list = Parser::parse_list(input.as_bytes()).unwrap();
-    bench.iter(|| parsed_list.serialize_value().unwrap());
-}
-
-fn serializing_dict(bench: &mut Bencher) {
-    let input = "a, dict_key2=abcdefghigklmnoprst, dict_key3=123456785686457, dict_key4=(\"inner-list-member\" :aW5uZXItbGlzdC1tZW1iZXI=:);key=aW5uZXItbGlzdC1wYXJhbWV0ZXJz";
-    let parsed_dict = Parser::parse_dictionary(input.as_bytes()).unwrap();
-    bench.iter(|| parsed_dict.serialize_value().unwrap());
-}
-
-benchmark_group!(
-    benches,
-    parsing_item,
-    parsing_list,
-    parsing_dict,
+criterion_group!(
+    serializing,
     serializing_item,
     serializing_list,
     serializing_dict
 );
-benchmark_main!(benches);
+
+fn serializing_item(c: &mut Criterion) {
+    let fixture =
+        "c29tZXZlcnlsb25nc3RyaW5ndmFsdWVyZXByZXNlbnRlZGFzYnl0ZXNhbnNvbWVvdGhlcmxvbmdsaW5l";
+    c.bench_with_input(
+        BenchmarkId::new("serializing_item", fixture),
+        &fixture,
+        move |bench, &input| {
+            let parsed_item = Parser::parse_item(input.as_bytes()).unwrap();
+            bench.iter(|| parsed_item.serialize_value().unwrap());
+        },
+    );
+}
+
+fn serializing_list(c: &mut Criterion) {
+    let fixture = "a, abcdefghigklmnoprst, 123456785686457, 99999999999.999, (), (\"somelongstringvalue\" \"anotherlongstringvalue\";key=:c29tZXZlciBsb25nc3RyaW5ndmFsdWVyZXByZXNlbnRlZGFzYnl0ZXM: 145)";
+    c.bench_with_input(
+        BenchmarkId::new("serializing_list", fixture),
+        &fixture,
+        move |bench, &input| {
+            let parsed_list = Parser::parse_list(input.as_bytes()).unwrap();
+            bench.iter(|| parsed_list.serialize_value().unwrap());
+        },
+    );
+}
+
+fn serializing_dict(c: &mut Criterion) {
+    let fixture = "a, dict_key2=abcdefghigklmnoprst, dict_key3=123456785686457, dict_key4=(\"inner-list-member\" :aW5uZXItbGlzdC1tZW1iZXI=:);key=aW5uZXItbGlzdC1wYXJhbWV0ZXJz";
+    c.bench_with_input(
+        BenchmarkId::new("serializing_dict", fixture),
+        &fixture,
+        move |bench, &input| {
+            let parsed_dict = Parser::parse_dictionary(input.as_bytes()).unwrap();
+            bench.iter(|| parsed_dict.serialize_value().unwrap());
+        },
+    );
+}


### PR DESCRIPTION
This changes the bencher to criterion!

I noticed you don't run benches on CI, so I didn't add/change it. :) I also didn't change/add any benches, I just wanted to show you this neat library @undef1nd ! :)

Criterion is one of  my favorite libraries, and I hope you might enjoy it too! If not, I won't be offended if you close this.

This uses the method described in https://bheisler.github.io/criterion.rs/book/user_guide/benchmarking_with_inputs.html to cover the existing benchmarking cases.

From reading your tests and code, it seems like you may wish to have further work deriving the benchmarks from the fixtures in `tests/spec_tests`?

As for why you might prefer Criterion to `bencher`:

* You can set and compare baselines: https://bheisler.github.io/criterion.rs/book/user_guide/command_line_options.html#baselines
* With gnuplot installed you can get beautiful reports in the `target/criterion` folder:
![image](https://user-images.githubusercontent.com/130903/89106419-8e310880-d3de-11ea-93f9-15616f137cf9.png)
* The output is a bit cleaner: 
```
test result: ok. 0 passed; 0 failed; 74 ignored; 0 measured; 0 filtered out

     Running target\release\deps\bench-272aa01c5cd0567c.exe
parsing_item/c29tZXZlcnlsb25nc3RyaW5ndmFsdWVyZXByZXNlbnRlZGFzYnl0ZXNhbnNvbWVvdGhlcmxvbmdsaW5l
                        time:   [1.8256 us 1.8272 us 1.8290 us]
                        change: [+0.0503% +0.2067% +0.3452%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

parsing_list/a, abcdefghigklmnoprst, 123456785686457, 99999999999.999, (), ("somelongstringvalue" "a...
                        time:   [8.9248 us 8.9528 us 8.9827 us]
                        change: [+75.647% +76.620% +77.587%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

parsing_dict/a, dict_key2=abcdefghigklmnoprst, dict_key3=123456785686457, dict_key4=("inner-list-mem...
                        time:   [5.3266 us 5.3333 us 5.3408 us]
                        change: [-0.3320% +0.0254% +0.3779%] (p = 0.89 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

serializing_item/c29tZXZlcnlsb25nc3RyaW5ndmFsdWVyZXByZXNlbnRlZGFzYnl0ZXNhbnNvbWVvdGhlcmxvbmdsaW5l
                        time:   [1.1187 us 1.1198 us 1.1210 us]
                        change: [+0.0001% +0.1534% +0.3028%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

serializing_list/a, abcdefghigklmnoprst, 123456785686457, 99999999999.999, (), ("somelongstringvalue...
                        time:   [2.6935 us 2.7006 us 2.7074 us]
                        change: [-1.2719% -0.8292% -0.3762%] (p = 0.00 < 0.05)
                        Change within noise threshold.

serializing_dict/a, dict_key2=abcdefghigklmnoprst, dict_key3=123456785686457, dict_key4=("inner-list...
                        time:   [1.6210 us 1.6243 us 1.6279 us]
                        change: [-1.4315% -0.9569% -0.5011%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

```

To try for yourself, install `gnuplot` (optional), then run `cargo bench` and explore `target/criterion/report`!