### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -63,7 +63,7 @@ impl Serializer {
     #[deny(clippy::ptr_arg)]
     pub(crate) fn serialize_list(input_list: &List, output: &mut String) -> SFVResult<()> {
         // https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#ser-list
-        if input_list.len() == 0 {
+        if input_list.is_empty() {
             return Err("serialize_list: serializing empty field is not allowed");
         }
 
@@ -89,7 +89,7 @@ impl Serializer {
 
     pub(crate) fn serialize_dict(input_dict: &Dictionary, output: &mut String) -> SFVResult<()> {
         // https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#ser-dictionary
-        if input_dict.len() == 0 {
+        if input_dict.is_empty() {
             return Err("serialize_dictionary: serializing empty field is not allowed");
         }
 


### PR DESCRIPTION
With running `cargo clippy` locally, I got 1 error and 2 warnings. This PR will fix the warnings part.

The error is

```rust
error: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices.
  --> src/serializer.rs:64:46
   |
64 |     pub(crate) fn serialize_list(input_list: &List, output: &mut String) -> SFVResult<()> {
   |                                              ^^^^^
   |
note: the lint level is defined here
  --> src/serializer.rs:63:12
   |
63 |     #[deny(clippy::ptr_arg)]
   |            ^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
```

because the `List` type is an alias-ed type, I'm not sure if we should fix it with the clippy suggestion.