### PR TITLE
Address Clippy "needless borrow" lint

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -227,23 +227,23 @@ impl Parser {
         Err("parse_inner_list: the end of the inner list was not found")
     }
 
-    pub(crate) fn parse_bare_item(mut input_chars: &mut Peekable<Chars>) -> SFVResult<BareItem> {
+    pub(crate) fn parse_bare_item(input_chars: &mut Peekable<Chars>) -> SFVResult<BareItem> {
         // https://httpwg.org/specs/rfc8941.html#parse-bare-item
         if input_chars.peek().is_none() {
             return Err("parse_bare_item: empty item");
         }
 
         match input_chars.peek() {
-            Some(&'?') => Ok(BareItem::Boolean(Self::parse_bool(&mut input_chars)?)),
-            Some(&'"') => Ok(BareItem::String(Self::parse_string(&mut input_chars)?)),
+            Some(&'?') => Ok(BareItem::Boolean(Self::parse_bool(input_chars)?)),
+            Some(&'"') => Ok(BareItem::String(Self::parse_string(input_chars)?)),
             Some(&':') => Ok(BareItem::ByteSeq(Self::parse_byte_sequence(
-                &mut input_chars,
+                input_chars,
             )?)),
             Some(&c) if c == '*' || c.is_ascii_alphabetic() => {
-                Ok(BareItem::Token(Self::parse_token(&mut input_chars)?))
+                Ok(BareItem::Token(Self::parse_token(input_chars)?))
             }
             Some(&c) if c == '-' || c.is_ascii_digit() => {
-                match Self::parse_number(&mut input_chars)? {
+                match Self::parse_number(input_chars)? {
                     Num::Decimal(val) => Ok(BareItem::Decimal(val)),
                     Num::Integer(val) => Ok(BareItem::Integer(val)),
                 }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -104,12 +104,12 @@ impl Serializer {
                         Self::serialize_parameters(&item.params, output)?;
                     } else {
                         output.push('=');
-                        Self::serialize_item(&item, output)?;
+                        Self::serialize_item(item, output)?;
                     }
                 }
                 ListEntry::InnerList(inner_list) => {
                     output.push('=');
-                    Self::serialize_inner_list(&inner_list, output)?;
+                    Self::serialize_inner_list(inner_list, output)?;
                 }
             }
 


### PR DESCRIPTION
Clippy runs a needless borrow lint
https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow.

This commit addresses the lint instances in `parse_bare_item()`. Once
that is done, the method itself becomes a compiler warning. So this
change also removes a mut from the signature.

Old:

pub(crate) fn parse_bare_item(mut input_chars: &mut Peekable<Chars>)

New:
pub(crate) fn parse_bare_item(input_chars: &mut Peekable<Chars>)

This has the effect of making the function signature more aligned with
all the other parse_xyz methods.
