### PR TITLE
Fix one instance of push_str for a single char

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -135,7 +135,7 @@ impl Serializer {
 
             // If more values remain in inner_list, append a single SP to output
             if idx < items.len() - 1 {
-                output.push_str(" ");
+                output.push(' ');
             }
         }
         output.push(')');


### PR DESCRIPTION
Clippy has the lint
https://rust-lang.github.io/rust-clippy/master/index.html#single_char_add_str

There was one instance where `push_str()` was used to add a single SP
char. Other similar code used `push`. This change switches to `push()`,
which makes things consistent, and little Mr. Clippy happy.
