### PR TITLE
Update serialize_string valid char check format

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -258,7 +258,7 @@ impl Serializer {
             return Err("serialize_string: non-ascii character");
         }
 
-        let vchar_or_sp = |char| char == '\x7f' || (char >= '\x00' && char <= '\x1f');
+        let vchar_or_sp = |char| char == '\x7f' || ('\x00'..='\x1f').contains(&char);
         if value.chars().any(vchar_or_sp) {
             return Err("serialize_string: not a visible character");
         }


### PR DESCRIPTION
Clippy has the manual_range_contains lint
https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains

This change converts the valid character check in `serialize_string()`
to the range format that Clippy suggests.
