### PR TITLE
tests: detect and warn missing spec_tests submodule

### DIFF
--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -328,7 +328,13 @@ fn run_spec_serialize_only_tests() -> Result<(), Box<dyn Error>> {
         .join("tests")
         .join("spec_tests")
         .join("serialisation-tests");
-    let json_files = fs::read_dir(test_suites_dir)?
+    let read_dir = match fs::read_dir(test_suites_dir) {
+        Ok(dir) => dir,
+
+        _ => panic!("Test suite directory not found! Check that the spec_tests git submodule has been retrieved.")
+    };
+
+    let json_files = read_dir
         .filter_map(Result::ok)
         .filter(|fp| fp.path().extension().unwrap_or_default() == "json");
 

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -330,7 +330,6 @@ fn run_spec_serialize_only_tests() -> Result<(), Box<dyn Error>> {
         .join("serialisation-tests");
     let read_dir = match fs::read_dir(test_suites_dir) {
         Ok(dir) => dir,
-
         _ => panic!("Test suite directory not found! Check that the spec_tests git submodule has been retrieved.")
     };
 


### PR DESCRIPTION
On a fresh checkout I forgot to clone recursively and the tests failed because I hadn't fetched the submodule containing the json test files. The test failure message is bit cryptic, so instead lets just panic with a more useful message that the user can action.