### PR TITLE
Add sf-date item variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,16 @@ exclude = ["tests/**", ".github/*"]
 indexmap="1.8.0"
 rust_decimal= { version = "1.20.0", default-features = false }
 data-encoding = "2.3.2"
+chrono = { version = "0.4.23", optional = true }
 
 [dev-dependencies]
 rust_decimal= { version = "1.20.0", default-features = false, features = ["std"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 criterion = "0.4.0"
+
+[features]
+sf-date-item = ["dep:chrono"]
 
 [[bench]]
 name = "bench"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,27 +1,15 @@
 #[macro_use]
 extern crate criterion;
 
-use std::convert::{TryFrom, TryInto};
-
 use criterion::{BenchmarkId, Criterion};
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
-use sfv::{BareItem, Parser, SerializeValue, Token};
+use sfv::{Parser, SerializeValue};
 use sfv::{RefBareItem, RefDictSerializer, RefItemSerializer, RefListSerializer};
 
 criterion_main!(parsing, serializing, ref_serializing);
 
 criterion_group!(parsing, parsing_item, parsing_list, parsing_dict);
-
-fn _trying_validation() -> Result<(), &'static str> {
-    let _token_try_from = Token::try_from("foo");
-    let _str_try_into: Token = "bar".try_into()?;
-    let _direct_construction = BareItem::Token("foo".try_into()?);
-
-    // let should_fail = Item::new(BareItem::Token(Token("foo".to_owned())));
-
-    Ok(())
-}
 
 fn parsing_item(c: &mut Criterion) {
     let fixture =

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,14 +1,26 @@
 #[macro_use]
 extern crate criterion;
 
+use std::convert::{TryFrom, TryInto};
+
 use criterion::{BenchmarkId, Criterion};
 use rust_decimal::prelude::FromPrimitive;
-use sfv::{BareItem, Decimal, Parser, SerializeValue};
+use sfv::{BareItem, Decimal, Parser, SerializeValue, Token};
 use sfv::{RefBareItem, RefDictSerializer, RefItemSerializer, RefListSerializer};
 
 criterion_main!(parsing, serializing, ref_serializing);
 
 criterion_group!(parsing, parsing_item, parsing_list, parsing_dict);
+
+fn _trying_validation() -> Result<(), &'static str> {
+    let _token_try_from = Token::try_from("foo");
+    let _str_try_into: Token = "bar".try_into()?;
+    let _direct_construction = BareItem::ValidatedToken("foo".try_into()?);
+
+    // let should_fail = Item::new(BareItem::ValidatedToken(Token("foo".to_owned())));
+
+    Ok(())
+}
 
 fn parsing_item(c: &mut Criterion) {
     let fixture =

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -16,9 +16,9 @@ criterion_group!(parsing, parsing_item, parsing_list, parsing_dict);
 fn _trying_validation() -> Result<(), &'static str> {
     let _token_try_from = Token::try_from("foo");
     let _str_try_into: Token = "bar".try_into()?;
-    let _direct_construction = BareItem::ValidatedToken("foo".try_into()?);
+    let _direct_construction = BareItem::Token("foo".try_into()?);
 
-    // let should_fail = Item::new(BareItem::ValidatedToken(Token("foo".to_owned())));
+    // let should_fail = Item::new(BareItem::Token(Token("foo".to_owned())));
 
     Ok(())
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,7 +5,8 @@ use std::convert::{TryFrom, TryInto};
 
 use criterion::{BenchmarkId, Criterion};
 use rust_decimal::prelude::FromPrimitive;
-use sfv::{BareItem, Decimal, Parser, SerializeValue, Token};
+use rust_decimal::Decimal;
+use sfv::{BareItem, Parser, SerializeValue, Token};
 use sfv::{RefBareItem, RefDictSerializer, RefItemSerializer, RefListSerializer};
 
 criterion_main!(parsing, serializing, ref_serializing);

--- a/src/bare_item.rs
+++ b/src/bare_item.rs
@@ -108,11 +108,17 @@ impl fmt::Display for BareItemString {
 /// base64    = ALPHA / DIGIT / "+" / "/" / "="
 /// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct ByteSeq(Vec<u8>);
+pub struct ByteSeq(pub(crate) Vec<u8>);
 
 impl From<&[u8]> for ByteSeq {
     fn from(value: &[u8]) -> Self {
         ByteSeq(value.to_vec())
+    }
+}
+
+impl From<Vec<u8>> for ByteSeq {
+    fn from(value: Vec<u8>) -> Self {
+        ByteSeq(value)
     }
 }
 

--- a/src/bare_item.rs
+++ b/src/bare_item.rs
@@ -1,4 +1,4 @@
-use crate::{serializer::Serializer, Num, Parser};
+use crate::serializer::Serializer;
 use std::{convert::TryFrom, fmt, ops::Deref};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -47,13 +47,9 @@ impl TryFrom<i64> for Integer {
     type Error = &'static str;
 
     fn try_from(value: i64) -> Result<Self, Self::Error> {
-        let input_string = value.to_string();
-        let mut input_chars = input_string.chars().peekable();
-        let validated = Parser::parse_number(&mut input_chars)?;
-        match validated {
-            Num::Integer(val) => Ok(Integer(val)),
-            Num::Decimal(_) => Err("Input is Decimal, expected Integer"),
-        }
+        let mut output = String::new();
+        Serializer::serialize_integer(value, &mut output)?;
+        Ok(Integer(value))
     }
 }
 

--- a/src/bare_item.rs
+++ b/src/bare_item.rs
@@ -11,7 +11,7 @@ use std::{convert::TryFrom, fmt, ops::Deref};
 /// sf-integer = ["-"] 1*15DIGIT
 /// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct Integer(i64);
+pub struct Integer(pub(crate) i64);
 
 impl Deref for Integer {
     type Target = i64;

--- a/src/bare_item.rs
+++ b/src/bare_item.rs
@@ -1,8 +1,31 @@
 use crate::{serializer::Serializer, Num, Parser};
 use std::{convert::TryFrom, fmt, ops::Deref};
 
-// TODO: Necessary? rust_decimal seems to validate already
-// pub struct Decimal(rust_decimal::Decimal);
+#[derive(Debug, PartialEq, Clone)]
+pub struct Decimal(pub(crate) rust_decimal::Decimal);
+
+impl TryFrom<rust_decimal::Decimal> for Decimal {
+    type Error = &'static str;
+    fn try_from(value: rust_decimal::Decimal) -> Result<Self, Self::Error> {
+        let mut output = String::new();
+        Serializer::serialize_decimal(value, &mut output)?;
+
+        Ok(Decimal(value))
+    }
+}
+
+impl Deref for Decimal {
+    type Target = rust_decimal::Decimal;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for Decimal {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// Integers have a range of -999,999,999,999,999 to 999,999,999,999,999 inclusive (i.e., up to fifteen digits, signed), for IEEE 754 compatibility.
 ///

--- a/src/bare_item.rs
+++ b/src/bare_item.rs
@@ -122,15 +122,6 @@ impl From<Vec<u8>> for ByteSeq {
     }
 }
 
-impl TryFrom<String> for ByteSeq {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        let mut input_chars = value.chars().peekable();
-        let validated = Parser::parse_byte_sequence(&mut input_chars)?;
-        Ok(ByteSeq(validated))
-    }
-}
-
 impl Deref for ByteSeq {
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
@@ -158,15 +149,6 @@ impl Deref for Boolean {
     type Target = bool;
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl TryFrom<String> for Boolean {
-    type Error = &'static str;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        let mut input_chars = value.chars().peekable();
-        let validated = Parser::parse_bool(&mut input_chars)?;
-        Ok(Boolean(validated))
     }
 }
 
@@ -227,9 +209,9 @@ impl TryFrom<String> for Token {
 impl TryFrom<&str> for Token {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let mut input_chars = value.chars().peekable();
-        let validated = Parser::parse_token(&mut input_chars)?;
-        Ok(Token(validated))
+        let mut output = String::new();
+        Serializer::serialize_token(&value, &mut output)?;
+        Ok(Token(value.to_owned()))
     }
 }
 

--- a/src/bare_item.rs
+++ b/src/bare_item.rs
@@ -184,12 +184,12 @@ impl fmt::Display for Boolean {
 ///
 /// # fn main() -> Result<(), &'static str> {
 /// let token_try_from = Token::try_from("foo")?;
-/// let item = BareItem::ValidatedToken(token_try_from);
+/// let item = BareItem::Token(token_try_from);
 ///
 /// let str_try_into: Token = "bar".try_into()?;
-/// let item = BareItem::ValidatedToken(str_try_into);
+/// let item = BareItem::Token(str_try_into);
 ///
-/// let direct_item_construction = BareItem::ValidatedToken("baz".try_into()?);
+/// let direct_item_construction = BareItem::Token("baz".try_into()?);
 /// # Ok(())
 /// # }
 /// ```
@@ -198,7 +198,7 @@ impl fmt::Display for Boolean {
 /// Token("foo"); // A Token can not be constructed directly
 /// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct Token(String);
+pub struct Token(pub(crate) String);
 
 impl Deref for Token {
     type Target = String;
@@ -211,9 +211,10 @@ impl Deref for Token {
 impl TryFrom<String> for Token {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        let mut input_chars = value.chars().peekable();
-        let validated = Parser::parse_token(&mut input_chars)?;
-        Ok(Token(validated))
+        let mut output = String::new();
+        Serializer::serialize_token(&value, &mut output)?;
+
+        Ok(Token(value))
     }
 }
 

--- a/src/bare_item.rs
+++ b/src/bare_item.rs
@@ -146,7 +146,7 @@ impl Deref for ByteSeq {
 /// boolean    = "0" / "1"
 /// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct Boolean(bool);
+pub struct Boolean(pub(crate) bool);
 
 impl From<bool> for Boolean {
     fn from(value: bool) -> Self {

--- a/src/bare_item.rs
+++ b/src/bare_item.rs
@@ -1,5 +1,163 @@
 use crate::serializer::Serializer;
-use std::{convert::TryFrom, fmt, ops::Deref};
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt,
+    ops::Deref,
+};
+
+/// `BareItem` type is used to construct `Items` or `Parameters` values.
+#[derive(Debug, PartialEq, Clone)]
+pub enum BareItem {
+    /// Decimal number
+    // sf-decimal  = ["-"] 1*12DIGIT "." 1*3DIGIT
+    Decimal(Decimal),
+    /// Integer number
+    // sf-integer = ["-"] 1*15DIGIT
+    Integer(Integer),
+    // sf-string = DQUOTE *chr DQUOTE
+    // chr       = unescaped / escaped
+    // unescaped = %x20-21 / %x23-5B / %x5D-7E
+    // escaped   = "\" ( DQUOTE / "\" )
+    String(BareItemString),
+    // ":" *(base64) ":"
+    // base64    = ALPHA / DIGIT / "+" / "/" / "="
+    ByteSeq(ByteSeq),
+    // sf-boolean = "?" boolean
+    // boolean    = "0" / "1"
+    Boolean(Boolean),
+    // sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )
+    Token(Token),
+}
+
+impl BareItem {
+    /// If `BareItem` is a decimal, returns `Decimal`, otherwise returns `None`.
+    /// ```
+    /// # use sfv::{BareItem, FromPrimitive};
+    /// use rust_decimal::Decimal;
+    /// # use std::convert::TryInto;
+    /// # fn main() -> Result<(), &'static str> {
+    /// let decimal_number = Decimal::from_f64(415.566).unwrap();
+    /// let bare_item: BareItem = decimal_number.try_into()?;
+    /// assert_eq!(bare_item.as_decimal().unwrap(), decimal_number);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn as_decimal(&self) -> Option<rust_decimal::Decimal> {
+        match self {
+            BareItem::Decimal(val) => Some(val.0),
+            _ => None,
+        }
+    }
+    /// If `BareItem` is an integer, returns `i64`, otherwise returns `None`.
+    /// ```
+    /// # use sfv::BareItem;
+    /// # use std::convert::TryInto;
+    /// # fn main() -> Result<(), &'static str> {
+    /// let bare_item: BareItem = 100_i64.try_into()?;
+    /// assert_eq!(bare_item.as_int().unwrap(), 100);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn as_int(&self) -> Option<i64> {
+        match &self {
+            BareItem::Integer(val) => Some(**val),
+            _ => None,
+        }
+    }
+    /// If `BareItem` is `String`, returns `&str`, otherwise returns `None`.
+    /// ```
+    /// # use sfv::BareItem;
+    /// # use std::convert::TryInto;
+    /// # fn main() -> Result<(), &'static str> {
+    /// let bare_item = BareItem::String("foo".to_owned().try_into()?);
+    /// assert_eq!(bare_item.as_str().unwrap(), "foo");
+    /// Ok(())
+    /// # }
+    /// ```
+    pub fn as_str(&self) -> Option<&str> {
+        match *self {
+            BareItem::String(ref val) => Some(val),
+            _ => None,
+        }
+    }
+    /// If `BareItem` is a `ByteSeq`, returns `&Vec<u8>`, otherwise returns `None`.
+    /// ```
+    /// # use sfv::BareItem;
+    /// let bare_item = BareItem::ByteSeq("foo".to_owned().into_bytes().into());
+    /// assert_eq!(bare_item.as_byte_seq().unwrap().as_slice(), "foo".as_bytes());
+    /// ```
+    pub fn as_byte_seq(&self) -> Option<&Vec<u8>> {
+        match *self {
+            BareItem::ByteSeq(ref val) => Some(&val.0),
+            _ => None,
+        }
+    }
+    /// If `BareItem` is a `Boolean`, returns `bool`, otherwise returns `None`.
+    /// ```
+    /// # use sfv::{BareItem, Decimal, FromPrimitive};
+    /// let bare_item = BareItem::Boolean(true.into());
+    /// assert_eq!(bare_item.as_bool().unwrap(), true);
+    /// ```
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            BareItem::Boolean(val) => Some(val.0),
+            _ => None,
+        }
+    }
+    /// If `BareItem` is a `Token`, returns `&str`, otherwise returns `None`.
+    /// ```
+    /// use sfv::BareItem;
+    /// # use std::convert::TryInto;
+    /// # fn main() -> Result<(), &'static str> {
+    ///
+    /// let bare_item = BareItem::Token("*bar".try_into()?);
+    /// assert_eq!(bare_item.as_token().unwrap(), "*bar");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn as_token(&self) -> Option<&str> {
+        match *self {
+            BareItem::Token(ref val) => Some(val),
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<i64> for BareItem {
+    type Error = &'static str;
+    /// Converts `i64` into `BareItem::Integer`.
+    /// ```
+    /// # use sfv::BareItem;
+    /// # use std::convert::TryInto;
+    /// # fn main() -> Result<(), &'static str> {
+    /// let bare_item: BareItem = 456_i64.try_into()?;
+    /// assert_eq!(bare_item.as_int().unwrap(), 456);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn try_from(item: i64) -> Result<Self, Self::Error> {
+        Ok(BareItem::Integer(item.try_into()?))
+    }
+}
+
+impl TryFrom<rust_decimal::Decimal> for BareItem {
+    type Error = &'static str;
+    /// Converts `rust_decimal::Decimal` into `BareItem::Decimal`.
+    /// ```
+    /// # use sfv::{BareItem, FromPrimitive};
+    /// # use std::convert::TryInto;
+    /// use rust_decimal::Decimal;
+    /// # fn main() -> Result<(), &'static str> {
+    /// let decimal_number = Decimal::from_f64(48.01).unwrap();
+    /// let bare_item: BareItem = decimal_number.try_into()?;
+    /// assert_eq!(bare_item.as_decimal().unwrap(), decimal_number);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn try_from(item: rust_decimal::Decimal) -> Result<Self, Self::Error> {
+        Ok(BareItem::Decimal(item.try_into()?))
+    }
+}
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Decimal(pub(crate) rust_decimal::Decimal);

--- a/src/bare_item.rs
+++ b/src/bare_item.rs
@@ -243,17 +243,30 @@ impl fmt::Display for Token {
 mod tests {
     use std::convert::TryInto;
     use std::error::Error;
+    use std::str::FromStr;
 
     use super::*;
 
     #[test]
     fn create_non_ascii_string_errors() -> Result<(), Box<dyn Error>> {
-        let disallowed_bare_item: Result<BareItemString, &str> =
+        let disallowed_value: Result<BareItemString, &str> =
             "non-ascii text 🐹".to_owned().try_into();
 
         assert_eq!(
             Err("serialize_string: non-ascii character"),
-            disallowed_bare_item
+            disallowed_value
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn create_too_long_decimal_errors() -> Result<(), Box<dyn Error>> {
+        let disallowed_value: Result<Decimal, &str> =
+            rust_decimal::Decimal::from_str("12345678912345.123")?.try_into();
+        assert_eq!(
+            Err("serialize_decimal: integer component > 12 digits"),
+            disallowed_value
         );
 
         Ok(())

--- a/src/bare_item.rs
+++ b/src/bare_item.rs
@@ -1,0 +1,209 @@
+use crate::{Num, Parser};
+use std::{convert::TryFrom, fmt, ops::Deref};
+
+// TODO: Necessary? rust_decimal seems to validate already
+// pub struct Decimal(rust_decimal::Decimal);
+
+/// Integers have a range of -999,999,999,999,999 to 999,999,999,999,999 inclusive (i.e., up to fifteen digits, signed), for IEEE 754 compatibility.
+///
+/// The ABNF for Integers is:
+/// ```abnf,ignore,no_run
+/// sf-integer = ["-"] 1*15DIGIT
+/// ```
+#[derive(Debug, PartialEq, Clone)]
+pub struct Integer(i64);
+
+impl Deref for Integer {
+    type Target = i64;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TryFrom<i64> for Integer {
+    type Error = &'static str;
+
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        let input_string = value.to_string();
+        let mut input_chars = input_string.chars().peekable();
+        let validated = Parser::parse_number(&mut input_chars)?;
+        match validated {
+            Num::Integer(val) => Ok(Integer(val)),
+            Num::Decimal(_) => Err("Input is Decimal, expected Integer"),
+        }
+    }
+}
+
+impl fmt::Display for Integer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// TODO: how to get around naming collision without using std::string::String everywhere?
+/// Strings are zero or more printable ASCII (RFC0020) characters (i.e., the range %x20 to %x7E). Note that this excludes tabs, newlines, carriage returns, etc.
+///
+/// The ABNF for Strings is:
+/// ```abnf,ignore,no_run
+/// sf-string = DQUOTE *chr DQUOTE
+/// chr       = unescaped / escaped
+/// unescaped = %x20-21 / %x23-5B / %x5D-7E
+/// escaped   = "\" ( DQUOTE / "\" )
+/// ```
+#[derive(Debug, PartialEq, Clone)]
+pub struct BareItemString(std::string::String);
+
+impl Deref for BareItemString {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for BareItemString {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let mut input_chars = value.chars().peekable();
+        let validated = Parser::parse_string(&mut input_chars)?;
+        Ok(BareItemString(validated))
+    }
+}
+
+impl fmt::Display for BareItemString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Byte Sequences can be conveyed in Structured Fields.
+///
+/// The ABNF for a Byte Sequence is:
+/// ```abnf,ignore,no_run
+/// sf-binary = ":" *(base64) ":"
+/// base64    = ALPHA / DIGIT / "+" / "/" / "="
+/// ```
+#[derive(Debug, PartialEq, Clone)]
+pub struct ByteSeq(Vec<u8>);
+
+impl From<&[u8]> for ByteSeq {
+    fn from(value: &[u8]) -> Self {
+        ByteSeq(value.to_vec())
+    }
+}
+
+impl TryFrom<String> for ByteSeq {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let mut input_chars = value.chars().peekable();
+        let validated = Parser::parse_byte_sequence(&mut input_chars)?;
+        Ok(ByteSeq(validated))
+    }
+}
+
+impl Deref for ByteSeq {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+/// Boolean values can be conveyed in Structured Fields.
+///
+/// The ABNF for a Boolean is:
+/// ```abnf,ignore,no_run
+/// sf-boolean = "?" boolean
+/// boolean    = "0" / "1"
+/// ```
+#[derive(Debug, PartialEq, Clone)]
+pub struct Boolean(bool);
+
+impl From<bool> for Boolean {
+    fn from(value: bool) -> Self {
+        Boolean(value)
+    }
+}
+
+impl Deref for Boolean {
+    type Target = bool;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for Boolean {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let mut input_chars = value.chars().peekable();
+        let validated = Parser::parse_bool(&mut input_chars)?;
+        Ok(Boolean(validated))
+    }
+}
+
+impl fmt::Display for Boolean {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Tokens are short textual words; their abstract model is identical to their expression in the HTTP field value serialization.
+///
+/// The ABNF for Tokens is:
+/// ```abnf,ignore,no_run
+/// sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )
+/// ```
+///
+/// # Example
+/// ```
+/// use sfv::{BareItem, Token};
+/// use std::convert::{TryFrom, TryInto};
+///
+/// # fn main() -> Result<(), &'static str> {
+/// let token_try_from = Token::try_from("foo")?;
+/// let item = BareItem::ValidatedToken(token_try_from);
+///
+/// let str_try_into: Token = "bar".try_into()?;
+/// let item = BareItem::ValidatedToken(str_try_into);
+///
+/// let direct_item_construction = BareItem::ValidatedToken("baz".try_into()?);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// Token("foo"); // A Token can not be constructed directly
+/// ```
+#[derive(Debug, PartialEq, Clone)]
+pub struct Token(String);
+
+impl Deref for Token {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for Token {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let mut input_chars = value.chars().peekable();
+        let validated = Parser::parse_token(&mut input_chars)?;
+        Ok(Token(validated))
+    }
+}
+
+impl TryFrom<&str> for Token {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let mut input_chars = value.chars().peekable();
+        let validated = Parser::parse_token(&mut input_chars)?;
+        Ok(Token(validated))
+    }
+}
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,26 @@ let dict_header = "u=2, n=(* foo 2)";
                 // do something if it's a ByteSeq
                 println!("{:?}", val);
             }
+            BareItem::ValidatedToken(val) => {
+                // do something if it's a Token
+                println!("{}", val);
+            }
+            BareItem::ValidatedInteger(val) => {
+                // do something if it's an Integer
+                println!("{}", val);
+            }
+            BareItem::ValidatedBoolean(val) => {
+                // do something if it's a Boolean
+                println!("{}", val);
+            }
+            BareItem::ValidatedString(val) => {
+                // do something if it's a String
+                println!("{}", val);
+            }
+            BareItem::ValidatedByteSeq(val) => {
+                // do something if it's a ByteSeq
+                println!("{:?}", val);
+            }
         },
         Some(ListEntry::InnerList(inner_list)) => {
             // do something if it's an InnerList
@@ -164,6 +184,7 @@ assert_eq!(
 ```
 */
 
+mod bare_item;
 mod parser;
 mod ref_serializer;
 mod serializer;
@@ -183,6 +204,8 @@ pub use rust_decimal::{
 pub use parser::{ParseMore, ParseValue, Parser};
 pub use ref_serializer::{RefDictSerializer, RefItemSerializer, RefListSerializer};
 pub use serializer::SerializeValue;
+
+pub use bare_item::{BareItemString, Boolean, ByteSeq, Integer, Token};
 
 type SFVResult<T> = std::result::Result<T, &'static str>;
 
@@ -304,6 +327,14 @@ pub enum BareItem {
     Boolean(bool),
     // sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )
     Token(String),
+
+    // TODO: needed?
+    // ValidatedDecimal(Decimal),
+    ValidatedInteger(Integer),
+    ValidatedString(BareItemString),
+    ValidatedByteSeq(ByteSeq),
+    ValidatedBoolean(Boolean),
+    ValidatedToken(Token),
 }
 
 impl BareItem {
@@ -435,6 +466,13 @@ impl BareItem {
             BareItem::ByteSeq(val) => RefBareItem::ByteSeq(val.as_slice()),
             BareItem::Boolean(val) => RefBareItem::Boolean(*val),
             BareItem::Token(val) => RefBareItem::Token(val),
+
+            BareItem::ValidatedInteger(val) => RefBareItem::Integer(**val),
+            // TODO: Decimal case
+            BareItem::ValidatedString(val) => RefBareItem::String(val),
+            BareItem::ValidatedByteSeq(val) => RefBareItem::ByteSeq(val),
+            BareItem::ValidatedBoolean(val) => RefBareItem::Boolean(**val),
+            BareItem::ValidatedToken(val) => RefBareItem::Token(&val),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,6 @@ let dict_header = "u=2, n=(* foo 2)";
                 // do something if it's a ByteSeq
                 println!("{:?}", val);
             }
-            BareItem::ValidatedBoolean(val) => {
-                // do something if it's a Boolean
-                println!("{}", val);
-            }
         },
         Some(ListEntry::InnerList(inner_list)) => {
             // do something if it's an InnerList
@@ -142,12 +138,12 @@ let str_item = Item::new(BareItem::String(String::from("foo").try_into()?));
 
 // Creates InnerList members.
 let mut int_item_params = Parameters::new();
-int_item_params.insert("key".into(), BareItem::Boolean(false));
+int_item_params.insert("key".into(), BareItem::Boolean(false.into()));
 let int_item = Item::with_params(BareItem::Integer(99_i64.try_into()?), int_item_params);
 
 // Creates InnerList.
 let mut inner_list_params = Parameters::new();
-inner_list_params.insert("bar".into(), BareItem::Boolean(true));
+inner_list_params.insert("bar".into(), BareItem::Boolean(true.into()));
 let inner_list = InnerList::with_params(vec![int_item, str_item], inner_list_params);
 
 
@@ -169,8 +165,8 @@ use sfv::{Parser, Item, BareItem, SerializeValue, ParseValue, Dictionary};
 # fn main() -> Result<(), &'static str> {
 
 let member_value1 = Item::new(BareItem::String(String::from("apple").try_into()?));
-let member_value2 = Item::new(BareItem::Boolean(true));
-let member_value3 = Item::new(BareItem::Boolean(false));
+let member_value2 = Item::new(BareItem::Boolean(true.into()));
+let member_value3 = Item::new(BareItem::Boolean(false.into()));
 
 let mut dict = Dictionary::new();
 dict.insert("key1".into(), member_value1.into());
@@ -327,11 +323,9 @@ pub enum BareItem {
     ByteSeq(ByteSeq),
     // sf-boolean = "?" boolean
     // boolean    = "0" / "1"
-    Boolean(bool),
+    Boolean(Boolean),
     // sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )
     Token(Token),
-
-    ValidatedBoolean(Boolean),
 }
 
 impl BareItem {
@@ -400,12 +394,12 @@ impl BareItem {
     /// If `BareItem` is a `Boolean`, returns `bool`, otherwise returns `None`.
     /// ```
     /// # use sfv::{BareItem, Decimal, FromPrimitive};
-    /// let bare_item = BareItem::Boolean(true);
+    /// let bare_item = BareItem::Boolean(true.into());
     /// assert_eq!(bare_item.as_bool().unwrap(), true);
     /// ```
     pub fn as_bool(&self) -> Option<bool> {
-        match *self {
-            BareItem::Boolean(val) => Some(val),
+        match self {
+            BareItem::Boolean(val) => Some(val.0),
             _ => None,
         }
     }
@@ -489,10 +483,8 @@ impl BareItem {
             BareItem::Decimal(val) => RefBareItem::Decimal(**val),
             BareItem::String(val) => RefBareItem::String(val),
             BareItem::ByteSeq(val) => RefBareItem::ByteSeq(val),
-            BareItem::Boolean(val) => RefBareItem::Boolean(*val),
+            BareItem::Boolean(val) => RefBareItem::Boolean(**val),
             BareItem::Token(val) => RefBareItem::Token(&val),
-
-            BareItem::ValidatedBoolean(val) => RefBareItem::Boolean(**val),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,10 +90,6 @@ let dict_header = "u=2, n=(* foo 2)";
                 // do something if it's a Boolean
                 println!("{}", val);
             }
-            BareItem::ValidatedByteSeq(val) => {
-                // do something if it's a ByteSeq
-                println!("{:?}", val);
-            }
         },
         Some(ListEntry::InnerList(inner_list)) => {
             // do something if it's an InnerList
@@ -328,14 +324,13 @@ pub enum BareItem {
     String(BareItemString),
     // ":" *(base64) ":"
     // base64    = ALPHA / DIGIT / "+" / "/" / "="
-    ByteSeq(Vec<u8>),
+    ByteSeq(ByteSeq),
     // sf-boolean = "?" boolean
     // boolean    = "0" / "1"
     Boolean(bool),
     // sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )
     Token(Token),
 
-    ValidatedByteSeq(ByteSeq),
     ValidatedBoolean(Boolean),
 }
 
@@ -393,12 +388,12 @@ impl BareItem {
     /// If `BareItem` is a `ByteSeq`, returns `&Vec<u8>`, otherwise returns `None`.
     /// ```
     /// # use sfv::BareItem;
-    /// let bare_item = BareItem::ByteSeq("foo".to_owned().into_bytes());
+    /// let bare_item = BareItem::ByteSeq("foo".to_owned().into_bytes().into());
     /// assert_eq!(bare_item.as_byte_seq().unwrap().as_slice(), "foo".as_bytes());
     /// ```
     pub fn as_byte_seq(&self) -> Option<&Vec<u8>> {
         match *self {
-            BareItem::ByteSeq(ref val) => Some(val),
+            BareItem::ByteSeq(ref val) => Some(&val.0),
             _ => None,
         }
     }
@@ -493,11 +488,10 @@ impl BareItem {
             BareItem::Integer(val) => RefBareItem::Integer(**val),
             BareItem::Decimal(val) => RefBareItem::Decimal(**val),
             BareItem::String(val) => RefBareItem::String(val),
-            BareItem::ByteSeq(val) => RefBareItem::ByteSeq(val.as_slice()),
+            BareItem::ByteSeq(val) => RefBareItem::ByteSeq(val),
             BareItem::Boolean(val) => RefBareItem::Boolean(*val),
             BareItem::Token(val) => RefBareItem::Token(&val),
 
-            BareItem::ValidatedByteSeq(val) => RefBareItem::ByteSeq(val),
             BareItem::ValidatedBoolean(val) => RefBareItem::Boolean(**val),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ let dict_header = "u=2, n=(* foo 2)";
                 // do something if it's a ByteSeq
                 println!("{:?}", val);
             }
+             &_ => todo!("Placeholder for any other bare item to come")
         },
         Some(ListEntry::InnerList(inner_list)) => {
             // do something if it's an InnerList
@@ -318,6 +319,8 @@ pub enum RefBareItem<'a> {
     ByteSeq(&'a [u8]),
     Boolean(bool),
     Token(&'a str),
+    #[cfg(feature = "sf-date-item")]
+    Date(chrono::NaiveDateTime),
 }
 
 impl BareItem {
@@ -330,6 +333,8 @@ impl BareItem {
             BareItem::ByteSeq(val) => RefBareItem::ByteSeq(val),
             BareItem::Boolean(val) => RefBareItem::Boolean(**val),
             BareItem::Token(val) => RefBareItem::Token(&val),
+            #[cfg(feature = "sf-date-item")]
+            BareItem::Date(val) => RefBareItem::Date(**val),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,6 @@ let dict_header = "u=2, n=(* foo 2)";
                 // do something if it's a ByteSeq
                 println!("{:?}", val);
             }
-            BareItem::ValidatedToken(val) => {
-                // do something if it's a Token
-                println!("{}", val);
-            }
             BareItem::ValidatedBoolean(val) => {
                 // do something if it's a Boolean
                 println!("{}", val);
@@ -143,7 +139,7 @@ use sfv::{Item, BareItem, InnerList, List, SerializeValue, Parameters};
 # use std::convert::TryInto;
 # fn main() -> Result<(), &'static str> {
 
-let tok_item = BareItem::Token("tok".into());
+let tok_item = BareItem::Token("tok".try_into()?);
 
 // Creates Item.
 let str_item = Item::new(BareItem::String(String::from("foo").try_into()?));
@@ -337,11 +333,10 @@ pub enum BareItem {
     // boolean    = "0" / "1"
     Boolean(bool),
     // sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )
-    Token(String),
+    Token(Token),
 
     ValidatedByteSeq(ByteSeq),
     ValidatedBoolean(Boolean),
-    ValidatedToken(Token),
 }
 
 impl BareItem {
@@ -422,9 +417,13 @@ impl BareItem {
     /// If `BareItem` is a `Token`, returns `&str`, otherwise returns `None`.
     /// ```
     /// use sfv::BareItem;
+    /// # use std::convert::TryInto;
+    /// # fn main() -> Result<(), &'static str> {
     ///
-    /// let bare_item = BareItem::Token("*bar".into());
+    /// let bare_item = BareItem::Token("*bar".try_into()?);
     /// assert_eq!(bare_item.as_token().unwrap(), "*bar");
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn as_token(&self) -> Option<&str> {
         match *self {
@@ -496,11 +495,10 @@ impl BareItem {
             BareItem::String(val) => RefBareItem::String(val),
             BareItem::ByteSeq(val) => RefBareItem::ByteSeq(val.as_slice()),
             BareItem::Boolean(val) => RefBareItem::Boolean(*val),
-            BareItem::Token(val) => RefBareItem::Token(val),
+            BareItem::Token(val) => RefBareItem::Token(&val),
 
             BareItem::ValidatedByteSeq(val) => RefBareItem::ByteSeq(val),
             BareItem::ValidatedBoolean(val) => RefBareItem::Boolean(**val),
-            BareItem::ValidatedToken(val) => RefBareItem::Token(&val),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::utils;
+use crate::{bare_item, utils};
 use crate::{
     BareItem, Decimal, Dictionary, FromStr, InnerList, Item, List, ListEntry, Num, Parameters,
     SFVResult,
@@ -242,7 +242,7 @@ impl Parser {
             }
             Some(&c) if c == '-' || c.is_ascii_digit() => match Self::parse_number(input_chars)? {
                 Num::Decimal(val) => Ok(BareItem::Decimal(val)),
-                Num::Integer(val) => Ok(BareItem::Integer(val)),
+                Num::Integer(val) => Ok(BareItem::Integer(bare_item::Integer(val))),
             },
             _ => Err("parse_bare_item: item type can't be identified"),
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -378,14 +378,14 @@ impl Parser {
         match chars_after_dot {
             Some(0) => Err("parse_number: decimal ends with '.'"),
             Some(1..=3) => {
-                let mut output_number = Decimal::from_str(&input_number)
+                let mut output_number = rust_decimal::Decimal::from_str(&input_number)
                     .map_err(|_err| "parse_number: parsing f64 failed")?;
 
                 if sign == -1 {
                     output_number.set_sign_negative(true)
                 }
 
-                Ok(Num::Decimal(output_number))
+                Ok(Num::Decimal(Decimal(output_number)))
             }
             _ => Err("parse_number: invalid decimal fraction length"),
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use crate::{bare_item, utils};
 use crate::{
     BareItem, Decimal, Dictionary, FromStr, InnerList, Item, List, ListEntry, Num, Parameters,
-    SFVResult,
+    SFVResult, Token,
 };
 use std::iter::Peekable;
 use std::str::{from_utf8, Chars};
@@ -240,7 +240,7 @@ impl Parser {
             ))),
             Some(&':') => Ok(BareItem::ByteSeq(Self::parse_byte_sequence(input_chars)?)),
             Some(&c) if c == '*' || c.is_ascii_alphabetic() => {
-                Ok(BareItem::Token(Self::parse_token(input_chars)?))
+                Ok(BareItem::Token(Token(Self::parse_token(input_chars)?)))
             }
             Some(&c) if c == '-' || c.is_ascii_digit() => match Self::parse_number(input_chars)? {
                 Num::Decimal(val) => Ok(BareItem::Decimal(val)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use crate::{bare_item, utils};
 use crate::{
-    BareItem, ByteSeq, Decimal, Dictionary, FromStr, InnerList, Item, List, ListEntry, Num,
-    Parameters, SFVResult, Token,
+    BareItem, Boolean, ByteSeq, Decimal, Dictionary, FromStr, InnerList, Item, List, ListEntry,
+    Num, Parameters, SFVResult, Token,
 };
 use std::iter::Peekable;
 use std::str::{from_utf8, Chars};
@@ -91,7 +91,7 @@ impl ParseValue for Dictionary {
                 let value = true;
                 let params = Parser::parse_parameters(input_chars)?;
                 let member = Item {
-                    bare_item: BareItem::Boolean(value),
+                    bare_item: BareItem::Boolean(value.into()),
                     params,
                 };
                 dict.insert(this_key, member.into());
@@ -234,7 +234,7 @@ impl Parser {
         }
 
         match input_chars.peek() {
-            Some(&'?') => Ok(BareItem::Boolean(Self::parse_bool(input_chars)?)),
+            Some(&'?') => Ok(BareItem::Boolean(Boolean(Self::parse_bool(input_chars)?))),
             Some(&'"') => Ok(BareItem::String(bare_item::BareItemString(
                 Self::parse_string(input_chars)?,
             ))),
@@ -444,7 +444,7 @@ impl Parser {
                     input_chars.next();
                     Self::parse_bare_item(input_chars)?
                 }
-                _ => BareItem::Boolean(true),
+                _ => BareItem::Boolean(true.into()),
             };
             params.insert(param_name, param_value);
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use crate::{bare_item, utils};
 use crate::{
-    BareItem, Decimal, Dictionary, FromStr, InnerList, Item, List, ListEntry, Num, Parameters,
-    SFVResult, Token,
+    BareItem, ByteSeq, Decimal, Dictionary, FromStr, InnerList, Item, List, ListEntry, Num,
+    Parameters, SFVResult, Token,
 };
 use std::iter::Peekable;
 use std::str::{from_utf8, Chars};
@@ -238,7 +238,9 @@ impl Parser {
             Some(&'"') => Ok(BareItem::String(bare_item::BareItemString(
                 Self::parse_string(input_chars)?,
             ))),
-            Some(&':') => Ok(BareItem::ByteSeq(Self::parse_byte_sequence(input_chars)?)),
+            Some(&':') => Ok(BareItem::ByteSeq(ByteSeq(Self::parse_byte_sequence(
+                input_chars,
+            )?))),
             Some(&c) if c == '*' || c.is_ascii_alphabetic() => {
                 Ok(BareItem::Token(Token(Self::parse_token(input_chars)?)))
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -235,7 +235,9 @@ impl Parser {
 
         match input_chars.peek() {
             Some(&'?') => Ok(BareItem::Boolean(Self::parse_bool(input_chars)?)),
-            Some(&'"') => Ok(BareItem::String(Self::parse_string(input_chars)?)),
+            Some(&'"') => Ok(BareItem::String(bare_item::BareItemString(
+                Self::parse_string(input_chars)?,
+            ))),
             Some(&':') => Ok(BareItem::ByteSeq(Self::parse_byte_sequence(input_chars)?)),
             Some(&c) if c == '*' || c.is_ascii_alphabetic() => {
                 Ok(BareItem::Token(Self::parse_token(input_chars)?))

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -115,7 +115,8 @@ impl<'a> RefListSerializer<'a> {
 
 /// Serializes `Dictionary` field value components incrementally.
 /// ```
-/// use sfv::{RefBareItem, RefDictSerializer, Decimal, FromPrimitive};
+/// use sfv::{RefBareItem, RefDictSerializer, FromPrimitive};
+/// use rust_decimal::Decimal;
 ///
 /// let mut serialized_item = String::new();
 /// let serializer = RefDictSerializer::new(&mut serialized_item);
@@ -245,7 +246,7 @@ impl<'a> Container<'a> for RefDictSerializer<'a> {
 #[cfg(test)]
 mod alternative_serializer_tests {
     use super::*;
-    use crate::{Decimal, FromPrimitive};
+    use crate::FromPrimitive;
 
     #[test]
     fn test_fast_serialize_item() -> SFVResult<()> {
@@ -287,7 +288,7 @@ mod alternative_serializer_tests {
             .bare_item_member("member2", &RefBareItem::Boolean(true))?
             .parameter(
                 "key3",
-                &RefBareItem::Decimal(Decimal::from_f64(45.4586).unwrap()),
+                &RefBareItem::Decimal(rust_decimal::Decimal::from_f64(45.4586).unwrap()),
             )?
             .parameter("key4", &RefBareItem::String("str"))?
             .open_inner_list("key5")?

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -98,7 +98,7 @@ impl Serializer {
                 ListEntry::Item(ref item) => {
                     // If dict member is boolean true, no need to serialize it: only its params must be serialized
                     // Otherwise serialize entire item with its params
-                    if item.bare_item == BareItem::Boolean(true) {
+                    if item.bare_item == BareItem::Boolean(true.into()) {
                         Self::serialize_parameters(&item.params, output)?;
                     } else {
                         output.push('=');

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -162,6 +162,8 @@ impl Serializer {
             RefBareItem::Token(value) => Self::serialize_token(value, output)?,
             RefBareItem::Integer(value) => Self::serialize_integer(*value, output)?,
             RefBareItem::Decimal(value) => Self::serialize_decimal(*value, output)?,
+            #[cfg(feature = "sf-date-item")]
+            RefBareItem::Date(value) => Self::serialize_date(*value, output)?,
         };
         Ok(())
     }
@@ -209,6 +211,19 @@ impl Serializer {
             }
         }
         output.push_str(input_key);
+        Ok(())
+    }
+
+    #[cfg(feature = "sf-date-item")]
+    pub(crate) fn serialize_date(
+        value: chrono::NaiveDateTime,
+        output: &mut String,
+    ) -> SFVResult<()> {
+        let mut integer_output = String::new();
+        Self::serialize_integer(value.timestamp(), &mut integer_output)
+            .map_err(|_| "serialize_date: date is out of range")?;
+        output.push('@');
+        output.push_str(&integer_output);
         Ok(())
     }
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,7 +1,6 @@
 use crate::utils;
 use crate::{
-    BareItem, Decimal, Dictionary, InnerList, Item, List, ListEntry, Parameters, RefBareItem,
-    SFVResult,
+    BareItem, Dictionary, InnerList, Item, List, ListEntry, Parameters, RefBareItem, SFVResult,
 };
 use data_encoding::BASE64;
 
@@ -224,7 +223,10 @@ impl Serializer {
         Ok(())
     }
 
-    pub(crate) fn serialize_decimal(value: Decimal, output: &mut String) -> SFVResult<()> {
+    pub(crate) fn serialize_decimal(
+        value: rust_decimal::Decimal,
+        output: &mut String,
+    ) -> SFVResult<()> {
         // https://httpwg.org/specs/rfc8941.html#ser-decimal
 
         let integer_comp_length = 12;

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -8,7 +8,7 @@ use std::iter::FromIterator;
 #[test]
 fn parse() -> Result<(), Box<dyn Error>> {
     let input = "\"some_value\"".as_bytes();
-    let parsed_item = Item::new(BareItem::String("some_value".to_owned()));
+    let parsed_item = Item::new(BareItem::String("some_value".to_owned().try_into()?));
     let expected = parsed_item;
     assert_eq!(expected, Parser::parse_item(input)?);
 
@@ -114,7 +114,7 @@ fn parse_list_of_items_and_lists_with_param() -> Result<(), Box<dyn Error>> {
     let item4 = Item::new(BareItem::Token("b".to_owned()));
     let inner_list_param = Parameters::from_iter(vec![(
         "param".to_owned(),
-        BareItem::String("param_value_1".to_owned()),
+        BareItem::String("param_value_1".to_owned().try_into()?),
     )]);
     let inner_list = InnerList::with_params(vec![item3, item4], inner_list_param);
     let empty_inner_list = InnerList::new(vec![]);
@@ -210,7 +210,7 @@ fn parse_item_decimal_with_bool_param_and_space() -> Result<(), Box<dyn Error>> 
 fn parse_item_number_with_param() -> Result<(), Box<dyn Error>> {
     let param = Parameters::from_iter(vec![("a1".to_owned(), BareItem::Token("*".to_owned()))]);
     assert_eq!(
-        Item::with_params(BareItem::String("12.35".to_owned()), param),
+        Item::with_params(BareItem::String("12.35".to_owned().try_into()?), param),
         Item::parse(&mut "\"12.35\";a1=*".chars().peekable())?
     );
     Ok(())
@@ -260,7 +260,10 @@ fn parse_dict_with_spaces_and_params() -> Result<(), Box<dyn Error>> {
     ]);
     let item3_params = Parameters::from_iter(vec![
         ("q".to_owned(), 9.try_into()?),
-        ("r".to_owned(), BareItem::String("+w".to_owned())),
+        (
+            "r".to_owned(),
+            BareItem::String("+w".to_owned().try_into()?),
+        ),
     ]);
 
     let item1 = Item::with_params(123.try_into()?, item1_params);
@@ -330,7 +333,7 @@ fn parse_bare_item() -> Result<(), Box<dyn Error>> {
         Parser::parse_bare_item(&mut "?0".chars().peekable())?
     );
     assert_eq!(
-        BareItem::String("test string".to_owned()),
+        BareItem::String("test string".to_owned().try_into()?),
         Parser::parse_bare_item(&mut "\"test string\"".chars().peekable())?
     );
     assert_eq!(
@@ -717,7 +720,7 @@ fn parse_params_string() -> Result<(), Box<dyn Error>> {
     let mut input = ";b=\"param_val\"".chars().peekable();
     let expected = Parameters::from_iter(vec![(
         "b".to_owned(),
-        BareItem::String("param_val".to_owned()),
+        BareItem::String("param_val".to_owned().try_into()?),
     )]);
     assert_eq!(expected, Parser::parse_parameters(&mut input)?);
     Ok(())

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -14,7 +14,7 @@ fn parse() -> Result<(), Box<dyn Error>> {
     assert_eq!(expected, Parser::parse_item(input)?);
 
     let input = "12.35;a ".as_bytes();
-    let params = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true))]);
+    let params = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true.into()))]);
     let expected = Item::with_params(Decimal::from_str("12.35")?.try_into()?, params);
 
     assert_eq!(expected, Parser::parse_item(input)?);
@@ -201,7 +201,7 @@ fn parse_item_int_with_space() -> Result<(), Box<dyn Error>> {
 #[test]
 fn parse_item_decimal_with_bool_param_and_space() -> Result<(), Box<dyn Error>> {
     let mut input = "12.35;a ".chars().peekable();
-    let param = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true))]);
+    let param = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true.into()))]);
     assert_eq!(
         Item::with_params(Decimal::from_str("12.35")?.try_into()?, param),
         Item::parse(&mut input)?
@@ -303,7 +303,7 @@ fn parse_dict_with_token_param() -> Result<(), Box<dyn Error>> {
         BareItem::Token("*".to_owned().try_into()?),
     )]);
     let item1 = Item::new(1.try_into()?);
-    let item2 = Item::with_params(BareItem::Boolean(true), item2_params);
+    let item2 = Item::with_params(BareItem::Boolean(true.into()), item2_params);
     let item3 = Item::new(3.try_into()?);
     let expected_dict = Dictionary::from_iter(vec![
         ("a".to_owned(), item1.into()),
@@ -337,7 +337,7 @@ fn parse_dict_multiple_spaces() -> Result<(), Box<dyn Error>> {
 #[test]
 fn parse_bare_item() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        BareItem::Boolean(false),
+        BareItem::Boolean(false.into()),
         Parser::parse_bare_item(&mut "?0".chars().peekable())?
     );
     assert_eq!(
@@ -738,8 +738,8 @@ fn parse_params_string() -> Result<(), Box<dyn Error>> {
 fn parse_params_bool() -> Result<(), Box<dyn Error>> {
     let mut input = ";b;a".chars().peekable();
     let expected = Parameters::from_iter(vec![
-        ("b".to_owned(), BareItem::Boolean(true)),
-        ("a".to_owned(), BareItem::Boolean(true)),
+        ("b".to_owned(), BareItem::Boolean(true.into())),
+        ("a".to_owned(), BareItem::Boolean(true.into())),
     ]);
     assert_eq!(expected, Parser::parse_parameters(&mut input)?);
     Ok(())
@@ -749,7 +749,7 @@ fn parse_params_bool() -> Result<(), Box<dyn Error>> {
 fn parse_params_mixed_types() -> Result<(), Box<dyn Error>> {
     let mut input = ";key1=?0;key2=746.15".chars().peekable();
     let expected = Parameters::from_iter(vec![
-        ("key1".to_owned(), BareItem::Boolean(false)),
+        ("key1".to_owned(), BareItem::Boolean(false.into())),
         ("key2".to_owned(), Decimal::from_str("746.15")?.try_into()?),
     ]);
     assert_eq!(expected, Parser::parse_parameters(&mut input)?);
@@ -760,7 +760,7 @@ fn parse_params_mixed_types() -> Result<(), Box<dyn Error>> {
 fn parse_params_with_spaces() -> Result<(), Box<dyn Error>> {
     let mut input = "; key1=?0; key2=11111".chars().peekable();
     let expected = Parameters::from_iter(vec![
-        ("key1".to_owned(), BareItem::Boolean(false)),
+        ("key1".to_owned(), BareItem::Boolean(false.into())),
         ("key2".to_owned(), 11111.try_into()?),
     ]);
     assert_eq!(expected, Parser::parse_parameters(&mut input)?);
@@ -839,7 +839,7 @@ fn parse_more_dict() -> Result<(), Box<dyn Error>> {
         BareItem::Token("*".to_owned().try_into()?),
     )]);
     let item1 = Item::new(1.try_into()?);
-    let item2 = Item::with_params(BareItem::Boolean(true), item2_params);
+    let item2 = Item::with_params(BareItem::Boolean(true.into()), item2_params);
     let item3 = Item::new(3.try_into()?);
     let expected_dict = Dictionary::from_iter(vec![
         ("a".to_owned(), item1.into()),

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -349,7 +349,7 @@ fn parse_bare_item() -> Result<(), Box<dyn Error>> {
         Parser::parse_bare_item(&mut "*token".chars().peekable())?
     );
     assert_eq!(
-        BareItem::ByteSeq("base_64 encoding test".to_owned().into_bytes()),
+        BareItem::ByteSeq("base_64 encoding test".to_owned().into_bytes().into()),
         Parser::parse_bare_item(&mut ":YmFzZV82NCBlbmNvZGluZyB0ZXN0:".chars().peekable())?
     );
     assert_eq!(

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -1,6 +1,7 @@
 use crate::FromStr;
-use crate::{BareItem, Decimal, Dictionary, InnerList, Item, List, Num, Parameters};
+use crate::{BareItem, Dictionary, InnerList, Item, List, Num, Parameters};
 use crate::{ParseMore, ParseValue, Parser};
+use rust_decimal::Decimal;
 use std::convert::TryInto;
 use std::error::Error;
 use std::iter::FromIterator;
@@ -14,7 +15,7 @@ fn parse() -> Result<(), Box<dyn Error>> {
 
     let input = "12.35;a ".as_bytes();
     let params = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true))]);
-    let expected = Item::with_params(Decimal::from_str("12.35")?.into(), params);
+    let expected = Item::with_params(Decimal::from_str("12.35")?.try_into()?, params);
 
     assert_eq!(expected, Parser::parse_item(input)?);
     Ok(())
@@ -200,7 +201,7 @@ fn parse_item_decimal_with_bool_param_and_space() -> Result<(), Box<dyn Error>> 
     let mut input = "12.35;a ".chars().peekable();
     let param = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true))]);
     assert_eq!(
-        Item::with_params(Decimal::from_str("12.35")?.into(), param),
+        Item::with_params(Decimal::from_str("12.35")?.try_into()?, param),
         Item::parse(&mut input)?
     );
     Ok(())
@@ -345,7 +346,7 @@ fn parse_bare_item() -> Result<(), Box<dyn Error>> {
         Parser::parse_bare_item(&mut ":YmFzZV82NCBlbmNvZGluZyB0ZXN0:".chars().peekable())?
     );
     assert_eq!(
-        BareItem::Decimal(Decimal::from_str("-3.55")?),
+        BareItem::Decimal(Decimal::from_str("-3.55")?.try_into()?),
         Parser::parse_bare_item(&mut "-3.55".chars().peekable())?
     );
     Ok(())
@@ -606,37 +607,37 @@ fn parse_number_int() -> Result<(), Box<dyn Error>> {
 fn parse_number_decimal() -> Result<(), Box<dyn Error>> {
     let mut input = "00.42 test string".chars().peekable();
     assert_eq!(
-        Num::Decimal(Decimal::from_str("0.42")?),
+        Num::Decimal(Decimal::from_str("0.42")?.try_into()?),
         Parser::parse_number(&mut input)?
     );
     assert_eq!(" test string", input.collect::<String>());
 
     assert_eq!(
-        Num::Decimal(Decimal::from_str("1.5")?),
+        Num::Decimal(Decimal::from_str("1.5")?.try_into()?),
         Parser::parse_number(&mut "1.5.4.".chars().peekable())?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("1.8")?),
+        Num::Decimal(Decimal::from_str("1.8")?.try_into()?),
         Parser::parse_number(&mut "1.8.".chars().peekable())?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("1.7")?),
+        Num::Decimal(Decimal::from_str("1.7")?.try_into()?),
         Parser::parse_number(&mut "1.7.0".chars().peekable())?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("3.14")?),
+        Num::Decimal(Decimal::from_str("3.14")?.try_into()?),
         Parser::parse_number(&mut "3.14".chars().peekable())?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("-3.14")?),
+        Num::Decimal(Decimal::from_str("-3.14")?.try_into()?),
         Parser::parse_number(&mut "-3.14".chars().peekable())?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("123456789012.1")?),
+        Num::Decimal(Decimal::from_str("123456789012.1")?.try_into()?),
         Parser::parse_number(&mut "123456789012.1".chars().peekable())?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("1234567890.112")?),
+        Num::Decimal(Decimal::from_str("1234567890.112")?.try_into()?),
         Parser::parse_number(&mut "1234567890.112".chars().peekable())?
     );
 
@@ -742,7 +743,7 @@ fn parse_params_mixed_types() -> Result<(), Box<dyn Error>> {
     let mut input = ";key1=?0;key2=746.15".chars().peekable();
     let expected = Parameters::from_iter(vec![
         ("key1".to_owned(), BareItem::Boolean(false)),
-        ("key2".to_owned(), Decimal::from_str("746.15")?.into()),
+        ("key2".to_owned(), Decimal::from_str("746.15")?.try_into()?),
     ]);
     assert_eq!(expected, Parser::parse_parameters(&mut input)?);
     Ok(())

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -96,8 +96,10 @@ fn parse_list_of_lists_with_param_and_spaces() -> Result<(), Box<dyn Error>> {
     let mut input = "(  1  42  ); k=*".chars().peekable();
     let item1 = Item::new(1.try_into()?);
     let item2 = Item::new(42.try_into()?);
-    let inner_list_param =
-        Parameters::from_iter(vec![("k".to_owned(), BareItem::Token("*".to_owned()))]);
+    let inner_list_param = Parameters::from_iter(vec![(
+        "k".to_owned(),
+        BareItem::Token("*".to_owned().try_into()?),
+    )]);
     let inner_list = InnerList::with_params(vec![item1, item2], inner_list_param);
     let expected_list: List = vec![inner_list.into()];
     assert_eq!(expected_list, List::parse(&mut input)?);
@@ -111,8 +113,8 @@ fn parse_list_of_items_and_lists_with_param() -> Result<(), Box<dyn Error>> {
         .peekable();
     let item1 = Item::new(12.try_into()?);
     let item2 = Item::new(14.try_into()?);
-    let item3 = Item::new(BareItem::Token("a".to_owned()));
-    let item4 = Item::new(BareItem::Token("b".to_owned()));
+    let item3 = Item::new(BareItem::Token("a".to_owned().try_into()?));
+    let item4 = Item::new(BareItem::Token("b".to_owned().try_into()?));
     let inner_list_param = Parameters::from_iter(vec![(
         "param".to_owned(),
         BareItem::String("param_value_1".to_owned().try_into()?),
@@ -182,8 +184,8 @@ fn parse_inner_list_with_param_and_spaces() -> Result<(), Box<dyn Error>> {
     let mut input = "(c b); a=1".chars().peekable();
     let inner_list_param = Parameters::from_iter(vec![("a".to_owned(), 1.try_into()?)]);
 
-    let item1 = Item::new(BareItem::Token("c".to_owned()));
-    let item2 = Item::new(BareItem::Token("b".to_owned()));
+    let item1 = Item::new(BareItem::Token("c".to_owned().try_into()?));
+    let item2 = Item::new(BareItem::Token("b".to_owned().try_into()?));
     let expected = InnerList::with_params(vec![item1, item2], inner_list_param);
     assert_eq!(expected, Parser::parse_inner_list(&mut input)?);
     Ok(())
@@ -209,7 +211,10 @@ fn parse_item_decimal_with_bool_param_and_space() -> Result<(), Box<dyn Error>> 
 
 #[test]
 fn parse_item_number_with_param() -> Result<(), Box<dyn Error>> {
-    let param = Parameters::from_iter(vec![("a1".to_owned(), BareItem::Token("*".to_owned()))]);
+    let param = Parameters::from_iter(vec![(
+        "a1".to_owned(),
+        BareItem::Token("*".to_owned().try_into()?),
+    )]);
     assert_eq!(
         Item::with_params(BareItem::String("12.35".to_owned().try_into()?), param),
         Item::parse(&mut "\"12.35\";a1=*".chars().peekable())?
@@ -293,8 +298,10 @@ fn parse_dict_empty_value() -> Result<(), Box<dyn Error>> {
 #[test]
 fn parse_dict_with_token_param() -> Result<(), Box<dyn Error>> {
     let mut input = "a=1, b;foo=*, c=3".chars().peekable();
-    let item2_params =
-        Parameters::from_iter(vec![("foo".to_owned(), BareItem::Token("*".to_owned()))]);
+    let item2_params = Parameters::from_iter(vec![(
+        "foo".to_owned(),
+        BareItem::Token("*".to_owned().try_into()?),
+    )]);
     let item1 = Item::new(1.try_into()?);
     let item2 = Item::with_params(BareItem::Boolean(true), item2_params);
     let item3 = Item::new(3.try_into()?);
@@ -338,7 +345,7 @@ fn parse_bare_item() -> Result<(), Box<dyn Error>> {
         Parser::parse_bare_item(&mut "\"test string\"".chars().peekable())?
     );
     assert_eq!(
-        BareItem::Token("*token".to_owned()),
+        BareItem::Token("*token".to_owned().try_into()?),
         Parser::parse_bare_item(&mut "*token".chars().peekable())?
     );
     assert_eq!(
@@ -827,8 +834,10 @@ fn parse_more_list() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn parse_more_dict() -> Result<(), Box<dyn Error>> {
-    let item2_params =
-        Parameters::from_iter(vec![("foo".to_owned(), BareItem::Token("*".to_owned()))]);
+    let item2_params = Parameters::from_iter(vec![(
+        "foo".to_owned(),
+        BareItem::Token("*".to_owned().try_into()?),
+    )]);
     let item1 = Item::new(1.try_into()?);
     let item2 = Item::with_params(BareItem::Boolean(true), item2_params);
     let item3 = Item::new(3.try_into()?);

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -30,7 +30,7 @@ fn serialize_value_empty_list() -> Result<(), Box<dyn Error>> {
 fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn Error>> {
     let item1 = Item::new(Decimal::from_str("42.4568")?.into());
     let item2_param = Parameters::from_iter(vec![("itm2_p".to_owned(), BareItem::Boolean(true))]);
-    let item2 = Item::with_params(17.into(), item2_param);
+    let item2 = Item::with_params(17.try_into()?, item2_param);
 
     let inner_list_item1_param =
         Parameters::from_iter(vec![("in1_p".to_owned(), BareItem::Boolean(false))]);
@@ -69,8 +69,9 @@ fn serialize_value_errors() -> Result<(), Box<dyn Error>> {
         disallowed_item.serialize_value()
     );
 
-    let param_with_disallowed_key = Parameters::from_iter(vec![("_key".to_owned(), 13.into())]);
-    let disallowed_item = Item::with_params(12.into(), param_with_disallowed_key);
+    let param_with_disallowed_key =
+        Parameters::from_iter(vec![("_key".to_owned(), 13.try_into()?)]);
+    let disallowed_item = Item::with_params(12.try_into()?, param_with_disallowed_key);
     assert_eq!(
         Err("serialize_key: first character is not lcalpha or '*'"),
         disallowed_item.serialize_value()
@@ -111,7 +112,7 @@ fn serialize_validated_item_byteseq_with_param() -> Result<(), Box<dyn Error>> {
 #[test]
 fn serialize_item_without_params() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
-    let item = Item::new(1.into());
+    let item = Item::new(1.try_into()?);
     Serializer::serialize_item(&item, &mut buf)?;
     assert_eq!("1", &buf);
     Ok(())
@@ -395,7 +396,7 @@ fn serialize_params_numbers() -> Result<(), Box<dyn Error>> {
 
     let input = Parameters::from_iter(vec![
         ("key1".to_owned(), Decimal::from_str("746.15")?.into()),
-        ("key2".to_owned(), 11111.into()),
+        ("key2".to_owned(), 11111.try_into()?),
     ]);
     Serializer::serialize_parameters(&input, &mut buf)?;
     assert_eq!(";key1=746.15;key2=11111", &buf);
@@ -459,8 +460,8 @@ fn serialize_key_erros() -> Result<(), Box<dyn Error>> {
 fn serialize_list_of_items_and_inner_list() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
 
-    let item1 = Item::new(12.into());
-    let item2 = Item::new(14.into());
+    let item1 = Item::new(12.try_into()?);
+    let item2 = Item::new(14.try_into()?);
     let item3 = Item::new(BareItem::Token("a".to_owned()));
     let item4 = Item::new(BareItem::Token("b".to_owned()));
     let inner_list_param = Parameters::from_iter(vec![(
@@ -479,10 +480,10 @@ fn serialize_list_of_items_and_inner_list() -> Result<(), Box<dyn Error>> {
 fn serialize_list_of_lists() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
 
-    let item1 = Item::new(1.into());
-    let item2 = Item::new(2.into());
-    let item3 = Item::new(42.into());
-    let item4 = Item::new(43.into());
+    let item1 = Item::new(1.try_into()?);
+    let item2 = Item::new(2.try_into()?);
+    let item3 = Item::new(42.try_into()?);
+    let item4 = Item::new(43.try_into()?);
     let inner_list_1 = InnerList::new(vec![item1, item2]);
     let inner_list_2 = InnerList::new(vec![item3, item4]);
     let input: List = vec![inner_list_1.into(), inner_list_2.into()];
@@ -514,7 +515,7 @@ fn serialize_dictionary_with_params() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
 
     let item1_params = Parameters::from_iter(vec![
-        ("a".to_owned(), 1.into()),
+        ("a".to_owned(), 1.try_into()?),
         ("b".to_owned(), BareItem::Boolean(true)),
     ]);
     let item2_params = Parameters::new();
@@ -523,9 +524,9 @@ fn serialize_dictionary_with_params() -> Result<(), Box<dyn Error>> {
         ("r".to_owned(), BareItem::String("+w".to_owned())),
     ]);
 
-    let item1 = Item::with_params(123.into(), item1_params);
-    let item2 = Item::with_params(456.into(), item2_params);
-    let item3 = Item::with_params(789.into(), item3_params);
+    let item1 = Item::with_params(123.try_into()?, item1_params);
+    let item2 = Item::with_params(456.try_into()?, item2_params);
+    let item3 = Item::with_params(789.try_into()?, item3_params);
 
     let input = Dictionary::from_iter(vec![
         ("abc".to_owned(), item1.into()),

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -61,22 +61,8 @@ fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn Error>
     Ok(())
 }
 
-// TODO: serializing a value should never fail as now the construction of a value
-#[ignore = "Moved to bare_item::create_non_ascii_string_errors"]
 #[test]
 fn serialize_value_errors() -> Result<(), Box<dyn Error>> {
-    let disallowed_item = Item::new(BareItem::String("non-ascii text 🐹".to_owned().try_into()?));
-    assert_eq!(
-        Err("serialize_string: non-ascii character"),
-        disallowed_item.serialize_value()
-    );
-
-    let disallowed_item = Item::new(Decimal::from_str("12345678912345.123")?.try_into()?);
-    assert_eq!(
-        Err("serialize_decimal: integer component > 12 digits"),
-        disallowed_item.serialize_value()
-    );
-
     let param_with_disallowed_key =
         Parameters::from_iter(vec![("_key".to_owned(), 13.try_into()?)]);
     let disallowed_item = Item::with_params(12.try_into()?, param_with_disallowed_key);

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -30,11 +30,12 @@ fn serialize_value_empty_list() -> Result<(), Box<dyn Error>> {
 #[test]
 fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn Error>> {
     let item1 = Item::new(Decimal::from_str("42.4568")?.try_into()?);
-    let item2_param = Parameters::from_iter(vec![("itm2_p".to_owned(), BareItem::Boolean(true))]);
+    let item2_param =
+        Parameters::from_iter(vec![("itm2_p".to_owned(), BareItem::Boolean(true.into()))]);
     let item2 = Item::with_params(17.try_into()?, item2_param);
 
     let inner_list_item1_param =
-        Parameters::from_iter(vec![("in1_p".to_owned(), BareItem::Boolean(false))]);
+        Parameters::from_iter(vec![("in1_p".to_owned(), BareItem::Boolean(false.into()))]);
     let inner_list_item1 = Item::with_params(
         BareItem::String("str1".to_owned().try_into()?),
         inner_list_item1_param,
@@ -125,7 +126,7 @@ fn serialize_item_without_params() -> Result<(), Box<dyn Error>> {
 #[test]
 fn serialize_item_with_bool_true_param() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
-    let param = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true))]);
+    let param = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true.into()))]);
     let item = Item::with_params(Decimal::from_str("12.35")?.try_into()?, param);
     Serializer::serialize_item(&item, &mut buf)?;
     assert_eq!("12.35;a", &buf);
@@ -375,8 +376,8 @@ fn serialize_params_bool() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
 
     let input = Parameters::from_iter(vec![
-        ("*b".to_owned(), BareItem::Boolean(true)),
-        ("a.a".to_owned(), BareItem::Boolean(true)),
+        ("*b".to_owned(), BareItem::Boolean(true.into())),
+        ("a.a".to_owned(), BareItem::Boolean(true.into())),
     ]);
 
     Serializer::serialize_parameters(&input, &mut buf)?;
@@ -415,7 +416,7 @@ fn serialize_params_mixed_types() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
 
     let input = Parameters::from_iter(vec![
-        ("key1".to_owned(), BareItem::Boolean(false)),
+        ("key1".to_owned(), BareItem::Boolean(false.into())),
         (
             "key2".to_owned(),
             Decimal::from_str("1354.091878")?.try_into()?,
@@ -508,10 +509,10 @@ fn serialize_list_with_bool_item_and_bool_params() -> Result<(), Box<dyn Error>>
     let mut buf = String::new();
 
     let item1_params = Parameters::from_iter(vec![
-        ("a".to_owned(), BareItem::Boolean(true)),
-        ("b".to_owned(), BareItem::Boolean(false)),
+        ("a".to_owned(), BareItem::Boolean(true.into())),
+        ("b".to_owned(), BareItem::Boolean(false.into())),
     ]);
-    let item1 = Item::with_params(BareItem::Boolean(false), item1_params);
+    let item1 = Item::with_params(BareItem::Boolean(false.into()), item1_params);
     let item2 = Item::new(BareItem::Token("cde_456".to_owned().try_into()?));
 
     let input: List = vec![item1.into(), item2.into()];
@@ -526,11 +527,11 @@ fn serialize_dictionary_with_params() -> Result<(), Box<dyn Error>> {
 
     let item1_params = Parameters::from_iter(vec![
         ("a".to_owned(), 1.try_into()?),
-        ("b".to_owned(), BareItem::Boolean(true)),
+        ("b".to_owned(), BareItem::Boolean(true.into())),
     ]);
     let item2_params = Parameters::new();
     let item3_params = Parameters::from_iter(vec![
-        ("q".to_owned(), BareItem::Boolean(false)),
+        ("q".to_owned(), BareItem::Boolean(false.into())),
         (
             "r".to_owned(),
             BareItem::String("+w".to_owned().try_into()?),

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -86,21 +86,6 @@ fn serialize_item_byteseq_with_param() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn serialize_validated_item_byteseq_with_param() -> Result<(), Box<dyn Error>> {
-    let mut buf = String::new();
-
-    let item_param = ("a".to_owned(), BareItem::Token("*ab_1".try_into()?));
-    let item_param = Parameters::from_iter(vec![item_param]);
-    let item = Item::with_params(
-        BareItem::ByteSeq("parser".as_bytes().try_into()?),
-        item_param,
-    );
-    Serializer::serialize_item(&item, &mut buf)?;
-    assert_eq!(":cGFyc2Vy:;a=*ab_1", &buf);
-    Ok(())
-}
-
-#[test]
 fn serialize_item_without_params() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
     let item = Item::new(1.try_into()?);

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -34,11 +34,13 @@ fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn Error>
 
     let inner_list_item1_param =
         Parameters::from_iter(vec![("in1_p".to_owned(), BareItem::Boolean(false))]);
-    let inner_list_item1 =
-        Item::with_params(BareItem::String("str1".to_owned()), inner_list_item1_param);
+    let inner_list_item1 = Item::with_params(
+        BareItem::String("str1".to_owned().try_into()?),
+        inner_list_item1_param,
+    );
     let inner_list_item2_param = Parameters::from_iter(vec![(
         "in2_p".to_owned(),
-        BareItem::String("valu\\e".to_owned()),
+        BareItem::String("valu\\e".to_owned().try_into()?),
     )]);
     let inner_list_item2 =
         Item::with_params(BareItem::Token("str2".to_owned()), inner_list_item2_param);
@@ -55,9 +57,11 @@ fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn Error>
     Ok(())
 }
 
+// TODO: serializing a value should never fail as now the construction of a value
+#[ignore = "Moved to bare_item::create_non_ascii_string_errors"]
 #[test]
 fn serialize_value_errors() -> Result<(), Box<dyn Error>> {
-    let disallowed_item = Item::new(BareItem::String("non-ascii text 🐹".into()));
+    let disallowed_item = Item::new(BareItem::String("non-ascii text 🐹".to_owned().try_into()?));
     assert_eq!(
         Err("serialize_string: non-ascii character"),
         disallowed_item.serialize_value()
@@ -132,7 +136,7 @@ fn serialize_item_with_bool_true_param() -> Result<(), Box<dyn Error>> {
 fn serialize_item_with_token_param() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
     let param = Parameters::from_iter(vec![("a1".to_owned(), BareItem::Token("*tok".to_owned()))]);
-    let item = Item::with_params(BareItem::String("12.35".to_owned()), param);
+    let item = Item::with_params(BareItem::String("12.35".to_owned().try_into()?), param);
     Serializer::serialize_item(&item, &mut buf)?;
     assert_eq!("\"12.35\";a1=*tok", &buf);
     Ok(())
@@ -383,7 +387,7 @@ fn serialize_params_string() -> Result<(), Box<dyn Error>> {
 
     let input = Parameters::from_iter(vec![(
         "b".to_owned(),
-        BareItem::String("param_val".to_owned()),
+        BareItem::String("param_val".to_owned().try_into()?),
     )]);
     Serializer::serialize_parameters(&input, &mut buf)?;
     assert_eq!(";b=\"param_val\"", &buf);
@@ -466,7 +470,7 @@ fn serialize_list_of_items_and_inner_list() -> Result<(), Box<dyn Error>> {
     let item4 = Item::new(BareItem::Token("b".to_owned()));
     let inner_list_param = Parameters::from_iter(vec![(
         "param".to_owned(),
-        BareItem::String("param_value_1".to_owned()),
+        BareItem::String("param_value_1".to_owned().try_into()?),
     )]);
     let inner_list = InnerList::with_params(vec![item3, item4], inner_list_param);
     let input: List = vec![item1.into(), item2.into(), inner_list.into()];
@@ -521,7 +525,10 @@ fn serialize_dictionary_with_params() -> Result<(), Box<dyn Error>> {
     let item2_params = Parameters::new();
     let item3_params = Parameters::from_iter(vec![
         ("q".to_owned(), BareItem::Boolean(false)),
-        ("r".to_owned(), BareItem::String("+w".to_owned())),
+        (
+            "r".to_owned(),
+            BareItem::String("+w".to_owned().try_into()?),
+        ),
     ]);
 
     let item1 = Item::with_params(123.try_into()?, item1_params);

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -2,6 +2,7 @@ use crate::serializer::Serializer;
 use crate::FromStr;
 use crate::SerializeValue;
 use crate::{BareItem, Decimal, Dictionary, InnerList, Item, List, Parameters};
+use std::convert::TryInto;
 use std::error::Error;
 use std::iter::FromIterator;
 
@@ -84,6 +85,24 @@ fn serialize_item_byteseq_with_param() -> Result<(), Box<dyn Error>> {
     let item_param = ("a".to_owned(), BareItem::Token("*ab_1".into()));
     let item_param = Parameters::from_iter(vec![item_param]);
     let item = Item::with_params(BareItem::ByteSeq("parser".as_bytes().to_vec()), item_param);
+    Serializer::serialize_item(&item, &mut buf)?;
+    assert_eq!(":cGFyc2Vy:;a=*ab_1", &buf);
+    Ok(())
+}
+
+#[test]
+fn serialize_validated_item_byteseq_with_param() -> Result<(), Box<dyn Error>> {
+    let mut buf = String::new();
+
+    let item_param = (
+        "a".to_owned(),
+        BareItem::ValidatedToken("*ab_1".try_into()?),
+    );
+    let item_param = Parameters::from_iter(vec![item_param]);
+    let item = Item::with_params(
+        BareItem::ValidatedByteSeq("parser".as_bytes().try_into()?),
+        item_param,
+    );
     Serializer::serialize_item(&item, &mut buf)?;
     assert_eq!(":cGFyc2Vy:;a=*ab_1", &buf);
     Ok(())

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -49,7 +49,7 @@ fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn Error>
     );
     let inner_list_param = Parameters::from_iter(vec![(
         "inner_list_param".to_owned(),
-        BareItem::ByteSeq("weather".as_bytes().to_vec()),
+        BareItem::ByteSeq("weather".as_bytes().into()),
     )]);
     let inner_list =
         InnerList::with_params(vec![inner_list_item1, inner_list_item2], inner_list_param);
@@ -92,7 +92,7 @@ fn serialize_item_byteseq_with_param() -> Result<(), Box<dyn Error>> {
 
     let item_param = ("a".to_owned(), BareItem::Token("*ab_1".try_into()?));
     let item_param = Parameters::from_iter(vec![item_param]);
-    let item = Item::with_params(BareItem::ByteSeq("parser".as_bytes().to_vec()), item_param);
+    let item = Item::with_params(BareItem::ByteSeq("parser".as_bytes().into()), item_param);
     Serializer::serialize_item(&item, &mut buf)?;
     assert_eq!(":cGFyc2Vy:;a=*ab_1", &buf);
     Ok(())
@@ -105,7 +105,7 @@ fn serialize_validated_item_byteseq_with_param() -> Result<(), Box<dyn Error>> {
     let item_param = ("a".to_owned(), BareItem::Token("*ab_1".try_into()?));
     let item_param = Parameters::from_iter(vec![item_param]);
     let item = Item::with_params(
-        BareItem::ValidatedByteSeq("parser".as_bytes().try_into()?),
+        BareItem::ByteSeq("parser".as_bytes().try_into()?),
         item_param,
     );
     Serializer::serialize_item(&item, &mut buf)?;

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -43,8 +43,10 @@ fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn Error>
         "in2_p".to_owned(),
         BareItem::String("valu\\e".to_owned().try_into()?),
     )]);
-    let inner_list_item2 =
-        Item::with_params(BareItem::Token("str2".to_owned()), inner_list_item2_param);
+    let inner_list_item2 = Item::with_params(
+        BareItem::Token("str2".to_owned().try_into()?),
+        inner_list_item2_param,
+    );
     let inner_list_param = Parameters::from_iter(vec![(
         "inner_list_param".to_owned(),
         BareItem::ByteSeq("weather".as_bytes().to_vec()),
@@ -88,7 +90,7 @@ fn serialize_value_errors() -> Result<(), Box<dyn Error>> {
 fn serialize_item_byteseq_with_param() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
 
-    let item_param = ("a".to_owned(), BareItem::Token("*ab_1".into()));
+    let item_param = ("a".to_owned(), BareItem::Token("*ab_1".try_into()?));
     let item_param = Parameters::from_iter(vec![item_param]);
     let item = Item::with_params(BareItem::ByteSeq("parser".as_bytes().to_vec()), item_param);
     Serializer::serialize_item(&item, &mut buf)?;
@@ -100,10 +102,7 @@ fn serialize_item_byteseq_with_param() -> Result<(), Box<dyn Error>> {
 fn serialize_validated_item_byteseq_with_param() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
 
-    let item_param = (
-        "a".to_owned(),
-        BareItem::ValidatedToken("*ab_1".try_into()?),
-    );
+    let item_param = ("a".to_owned(), BareItem::Token("*ab_1".try_into()?));
     let item_param = Parameters::from_iter(vec![item_param]);
     let item = Item::with_params(
         BareItem::ValidatedByteSeq("parser".as_bytes().try_into()?),
@@ -136,7 +135,10 @@ fn serialize_item_with_bool_true_param() -> Result<(), Box<dyn Error>> {
 #[test]
 fn serialize_item_with_token_param() -> Result<(), Box<dyn Error>> {
     let mut buf = String::new();
-    let param = Parameters::from_iter(vec![("a1".to_owned(), BareItem::Token("*tok".to_owned()))]);
+    let param = Parameters::from_iter(vec![(
+        "a1".to_owned(),
+        BareItem::Token("*tok".to_owned().try_into()?),
+    )]);
     let item = Item::with_params(BareItem::String("12.35".to_owned().try_into()?), param);
     Serializer::serialize_item(&item, &mut buf)?;
     assert_eq!("\"12.35\";a1=*tok", &buf);
@@ -470,8 +472,8 @@ fn serialize_list_of_items_and_inner_list() -> Result<(), Box<dyn Error>> {
 
     let item1 = Item::new(12.try_into()?);
     let item2 = Item::new(14.try_into()?);
-    let item3 = Item::new(BareItem::Token("a".to_owned()));
-    let item4 = Item::new(BareItem::Token("b".to_owned()));
+    let item3 = Item::new(BareItem::Token("a".to_owned().try_into()?));
+    let item4 = Item::new(BareItem::Token("b".to_owned().try_into()?));
     let inner_list_param = Parameters::from_iter(vec![(
         "param".to_owned(),
         BareItem::String("param_value_1".to_owned().try_into()?),
@@ -510,7 +512,7 @@ fn serialize_list_with_bool_item_and_bool_params() -> Result<(), Box<dyn Error>>
         ("b".to_owned(), BareItem::Boolean(false)),
     ]);
     let item1 = Item::with_params(BareItem::Boolean(false), item1_params);
-    let item2 = Item::new(BareItem::Token("cde_456".to_owned()));
+    let item2 = Item::new(BareItem::Token("cde_456".to_owned().try_into()?));
 
     let input: List = vec![item1.into(), item2.into()];
     Serializer::serialize_list(&input, &mut buf)?;

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use sfv::FromStr;
 use sfv::Parser;
 use sfv::SerializeValue;
-use sfv::{BareItem, Decimal, Dictionary, InnerList, Item, List, ListEntry, Parameters};
+use sfv::{BareItem, Dictionary, InnerList, Item, List, ListEntry, Parameters};
 use std::convert::TryInto;
 use std::error::Error;
 use std::path::PathBuf;
@@ -247,8 +247,8 @@ fn build_bare_item(bare_item_value: &Value) -> Result<BareItem, Box<dyn Error>> 
                 .try_into()?,
         )),
         bare_item if bare_item.is_f64() => {
-            let decimal = Decimal::from_str(&serde_json::to_string(bare_item)?)?;
-            Ok(BareItem::Decimal(decimal))
+            let decimal = rust_decimal::Decimal::from_str(&serde_json::to_string(bare_item)?)?;
+            Ok(BareItem::Decimal(decimal.try_into()?))
         }
         bare_item if bare_item.is_boolean() => Ok(BareItem::Boolean(
             bare_item

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -270,7 +270,8 @@ fn build_bare_item(bare_item_value: &Value) -> Result<BareItem, Box<dyn Error>> 
                     .as_str()
                     .ok_or("build_bare_item: bare_item value is not a str")?
                     .clone()
-                    .to_owned(),
+                    .to_owned()
+                    .try_into()?,
             ))
         }
         bare_item if (bare_item.is_object() && bare_item["__type"] == "binary") => {

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -253,7 +253,8 @@ fn build_bare_item(bare_item_value: &Value) -> Result<BareItem, Box<dyn Error>> 
         bare_item if bare_item.is_boolean() => Ok(BareItem::Boolean(
             bare_item
                 .as_bool()
-                .ok_or("build_bare_item: bare_item value is not a bool")?,
+                .ok_or("build_bare_item: bare_item value is not a bool")?
+                .into(),
         )),
         bare_item if bare_item.is_string() => {
             let converted = bare_item

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -279,7 +279,7 @@ fn build_bare_item(bare_item_value: &Value) -> Result<BareItem, Box<dyn Error>> 
                 .as_str()
                 .ok_or("build_bare_item: bare_item value is not a str")?
                 .clone();
-            Ok(BareItem::ByteSeq(BASE32.decode(str_val.as_bytes())?))
+            Ok(BareItem::ByteSeq(BASE32.decode(str_val.as_bytes())?.into()))
         }
         _ => Err("build_bare_item: unknown bare_item value".into()),
     }


### PR DESCRIPTION
While I was waiting for the review on #102 I was eager to learn a bit more and found that the date support was a nice hook for me to get to work with cargo features. So here we go, I hope I'm not taking it away from someone 😅 

As I can't open a PR towards this repo targeting my previous branch, here's a link to get a proper diff of just the relevant commit: 

https://github.com/zcei/sfv/compare/validate-bare-items...zcei:sfv:feat/date