### PR TITLE
Stop allowing non-terminal padding bytes within byte sequences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,16 @@ exclude = ["tests/**", ".github/*"]
 
 
 [dependencies]
+base64 = "0.22.1"
 indexmap = "2"
 rust_decimal = { version = "1.20.0", default-features = false }
-data-encoding = "2.3.2"
 
 [dev-dependencies]
 rust_decimal = { version = "1.20.0", default-features = false, features = ["std"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 criterion = "0.4.0"
+base32 = "0.5.1"
 
 [[bench]]
 name = "bench"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -327,7 +327,7 @@ impl Parser {
         if !b64_content.chars().all(utils::is_allowed_b64_content) {
             return Err("parse_byte_seq: invalid char in byte sequence");
         }
-        match utils::base64()?.decode(b64_content.as_bytes()) {
+        match base64::Engine::decode(&utils::BASE64, b64_content) {
             Ok(content) => Ok(content),
             Err(_) => Err("parse_byte_seq: decoding error"),
         }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -3,7 +3,6 @@ use crate::{
     BareItem, Decimal, Dictionary, InnerList, Item, List, ListEntry, Parameters, RefBareItem,
     SFVResult,
 };
-use data_encoding::BASE64;
 
 /// Serializes structured field value into String.
 pub trait SerializeValue {
@@ -303,7 +302,7 @@ impl Serializer {
         // https://httpwg.org/specs/rfc8941.html#ser-binary
 
         output.push(':');
-        let encoded = BASE64.encode(value.as_ref());
+        let encoded = base64::Engine::encode(&utils::BASE64, value);
         output.push_str(&encoded);
         output.push(':');
         Ok(())

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -302,8 +302,7 @@ impl Serializer {
         // https://httpwg.org/specs/rfc8941.html#ser-binary
 
         output.push(':');
-        let encoded = base64::Engine::encode(&utils::BASE64, value);
-        output.push_str(&encoded);
+        base64::Engine::encode_string(&utils::BASE64, value, output);
         output.push(':');
         Ok(())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,17 +1,14 @@
-use data_encoding::{Encoding, Specification};
+use base64::engine;
 use std::iter::Peekable;
 use std::str::Chars;
 
-pub(crate) fn base64() -> Result<Encoding, &'static str> {
-    let mut spec = Specification::new();
-    spec.check_trailing_bits = false;
-    spec.symbols
-        .push_str("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
-    spec.padding = None;
-    spec.ignore = "=".to_owned();
-    spec.encoding()
-        .map_err(|_err| "invalid base64 specification")
-}
+pub(crate) const BASE64: engine::GeneralPurpose = engine::GeneralPurpose::new(
+    &base64::alphabet::STANDARD,
+    engine::GeneralPurposeConfig::new()
+        .with_decode_allow_trailing_bits(true)
+        .with_decode_padding_mode(engine::DecodePaddingMode::Indifferent)
+        .with_encode_padding(true),
+);
 
 pub(crate) fn is_tchar(c: char) -> bool {
     // See tchar values list in https://tools.ietf.org/html/rfc7230#section-3.2.6

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -1,4 +1,3 @@
-use data_encoding::BASE32;
 use serde::Deserialize;
 use serde_json::Value;
 use sfv::FromStr;
@@ -257,7 +256,10 @@ fn build_bare_item(bare_item_value: &Value) -> Result<BareItem, Box<dyn Error>> 
             let str_val = bare_item["value"]
                 .as_str()
                 .ok_or("build_bare_item: bare_item value is not a str")?;
-            Ok(BareItem::ByteSeq(BASE32.decode(str_val.as_bytes())?))
+            Ok(BareItem::ByteSeq(
+                base32::decode(base32::Alphabet::Rfc4648 { padding: true }, str_val)
+                    .ok_or("build_bare_item: invalid base32")?,
+            ))
         }
         _ => Err("build_bare_item: unknown bare_item value".into()),
     }


### PR DESCRIPTION
Previously, due to the way the `data-encoding` crate works, `=` was ignored anywhere it occurred, rather than only being treated as a padding byte. Unfortunately, this wasn't detected before due to the lack of specification-test coverage prior to
https://github.com/httpwg/structured-field-tests/pull/94.

In this change we replace `data-encoding` with the `base64` crate, allowing us to fix this behavior, which should require a version bump.