### PR TITLE
Remove redundant validation of base64 characters

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -324,9 +324,6 @@ impl Parser {
         }
 
         let b64_content = input_chars.take_while(|c| c != &':').collect::<String>();
-        if !b64_content.chars().all(utils::is_allowed_b64_content) {
-            return Err("parse_byte_seq: invalid char in byte sequence");
-        }
         match base64::Engine::decode(&utils::BASE64, b64_content) {
             Ok(content) => Ok(content),
             Err(_) => Err("parse_byte_seq: decoding error"),

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -529,7 +529,7 @@ fn parse_byte_sequence_errors() -> Result<(), Box<dyn Error>> {
         Parser::parse_byte_sequence(&mut "aGVsbG8".chars().peekable())
     );
     assert_eq!(
-        Err("parse_byte_seq: invalid char in byte sequence"),
+        Err("parse_byte_seq: decoding error"),
         Parser::parse_byte_sequence(&mut ":aGVsb G8=:".chars().peekable())
     );
     assert_eq!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,10 +16,6 @@ pub(crate) fn is_tchar(c: char) -> bool {
     tchars.contains(c) || c.is_ascii_alphanumeric()
 }
 
-pub(crate) fn is_allowed_b64_content(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '+' || c == '=' || c == '/'
-}
-
 pub(crate) fn consume_ows_chars(input_chars: &mut Peekable<Chars>) {
     while let Some(c) = input_chars.peek() {
         if c == &' ' || c == &'\t' {


### PR DESCRIPTION
The base64 decoding process already validates these.