### PR TITLE
Discard insignificant digits from decimals during serialization

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -233,7 +233,7 @@ impl Serializer {
 
         let fraction_length = 3;
 
-        let decimal = value.round_dp(fraction_length);
+        let decimal = value.round_dp(fraction_length).normalize();
         let int_comp = decimal.trunc();
         let fract_comp = decimal.fract();
 

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -177,7 +177,11 @@ fn serialize_decimal() -> Result<(), Box<dyn Error>> {
 
     buf.clear();
     Serializer::serialize_decimal(Decimal::from_str("-100.130")?, &mut buf)?;
-    assert_eq!("-100.130", &buf);
+    assert_eq!("-100.13", &buf);
+
+    buf.clear();
+    Serializer::serialize_decimal(Decimal::from_str("-100.100")?, &mut buf)?;
+    assert_eq!("-100.1", &buf);
 
     buf.clear();
     Serializer::serialize_decimal(Decimal::from_str("-137.0")?, &mut buf)?;


### PR DESCRIPTION
Per Step 9 of https://httpwg.org/specs/rfc8941.html#ser-decimal, only the significant digits of a decimal's fractional component are serialized.

Previously, this caused a decimal like `123.10` to be serialized verbatim rather than `123.1`. This was not caught by the specification tests because the parsing function happens to normalize the parsed value itself, and unfortunately the serialization-only specification tests cannot cover this case because there is no guarantee that a JSON number `123.10` will retain the trailing `0` on parsing.

In any case, this crate should not assume that a given decimal is already normalized during serialization.