### PR TITLE
Remove public export of ParseValue trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ assert_eq!(
 
 Creates `Dictionary` field value:
 ```
-use sfv::{Parser, Item, BareItem, SerializeValue, ParseValue, Dictionary};
+use sfv::{Parser, Item, BareItem, SerializeValue, Dictionary};
 
 let member_value1 = Item::new(BareItem::String(String::from("apple")));
 let member_value2 = Item::new(BareItem::Boolean(true));
@@ -180,7 +180,7 @@ pub use rust_decimal::{
     Decimal,
 };
 
-pub use parser::{ParseMore, ParseValue, Parser};
+pub use parser::{ParseMore, Parser};
 pub use ref_serializer::{RefDictSerializer, RefItemSerializer, RefListSerializer};
 pub use serializer::SerializeValue;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,8 +6,7 @@ use crate::{
 use std::iter::Peekable;
 use std::str::{from_utf8, Chars};
 
-/// Implements parsing logic for each structured field value type.
-pub trait ParseValue {
+pub(crate) trait ParseValue {
     /// This method should not be used for parsing input into structured field value.
     /// Use `Parser::parse_item`, `Parser::parse_list` or `Parsers::parse_dictionary` for that.
     fn parse(input_chars: &mut Peekable<Chars>) -> SFVResult<Self>

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -10,7 +10,7 @@ pub trait SerializeValue {
     /// Serializes structured field value into String.
     /// # Examples
     /// ```
-    /// # use sfv::{Parser, SerializeValue, ParseValue};
+    /// # use sfv::{Parser, SerializeValue};
     ///
     /// let parsed_list_field = Parser::parse_list("\"london\", \t\t\"berlin\"".as_bytes());
     /// assert!(parsed_list_field.is_ok());

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -1,6 +1,8 @@
-use crate::FromStr;
-use crate::{BareItem, Decimal, Dictionary, InnerList, Item, List, Num, Parameters};
-use crate::{ParseMore, ParseValue, Parser};
+use crate::parser::ParseValue;
+use crate::{
+    BareItem, Decimal, Dictionary, FromStr, InnerList, Item, List, Num, Parameters, ParseMore,
+    Parser,
+};
 use std::error::Error;
 use std::iter::FromIterator;
 


### PR DESCRIPTION
- The documentation for its lone method indicated that it shouldn't be called externally
- Its method was only callable if the trait was `use`d
- It was only meant to be implemented for types defined in the crate, but was not sealed
- The public `Parser` struct already provides the same functionality
- Its lone method's interface exposed internal representation of the parser (`&mut Peekable<Chars>`), which may be changed in the future to accommodate things like copy-less parsing or configurations like RFC 9651