### PR TITLE
Add basic fuzzers for parsing functions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -59,3 +59,19 @@ jobs:
           command: fmt
           toolchain: stable
           args: -- --check
+
+  fuzz-check:
+    name: Run fuzz check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - run: cargo install cargo-fuzz
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fuzz
+          args: check

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "sfv-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.sfv]
+path = ".."
+
+[[bin]]
+name = "parse_dictionary"
+path = "fuzz_targets/parse_dictionary.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_list"
+path = "fuzz_targets/parse_list.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_item"
+path = "fuzz_targets/parse_item.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse_dictionary.rs
+++ b/fuzz/fuzz_targets/parse_dictionary.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = sfv::Parser::parse_dictionary(data);
+});

--- a/fuzz/fuzz_targets/parse_item.rs
+++ b/fuzz/fuzz_targets/parse_item.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = sfv::Parser::parse_item(data);
+});

--- a/fuzz/fuzz_targets/parse_list.rs
+++ b/fuzz/fuzz_targets/parse_list.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = sfv::Parser::parse_list(data);
+});


### PR DESCRIPTION
For now in CI we only build the fuzz targets, rather than actually run them, which can be done locally using:

```sh
cargo +nightly fuzz run parse_dictionary
```