### PR TITLE
Check all targets on build

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --all-targets
 
   test:
     name: Run tests


### PR DESCRIPTION
Without this, it's easy for targets like benchmarks to bitrot.