### PR TITLE
Use strong types for key and bare item integer, decimal, token, and string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,12 @@ repository = "https://github.com/undef1nd/sfv"
 keywords = ["http-header", "structured-header", ]
 exclude = ["tests/**", ".github/*"]
 
-
 [dependencies]
 base64 = "0.22.1"
 indexmap = "2"
 ref-cast = "1.0.23"
-rust_decimal = { version = "1.20.0", default-features = false }
 
 [dev-dependencies]
-rust_decimal = { version = "1.20.0", default-features = false, features = ["std"] }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 criterion = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["http-header", "structured-header", ]
 exclude = ["tests/**", ".github/*"]
 
 [dependencies]
+arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
 base64 = "0.22.1"
 indexmap = "2"
 ref-cast = "1.0.23"
@@ -26,3 +27,6 @@ base32 = "0.5.1"
 [[bench]]
 name = "bench"
 harness = false
+
+[features]
+arbitrary = ["dep:arbitrary", "indexmap/arbitrary"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = ["tests/**", ".github/*"]
 [dependencies]
 base64 = "0.22.1"
 indexmap = "2"
+ref-cast = "1.0.23"
 rust_decimal = { version = "1.20.0", default-features = false }
 
 [dev-dependencies]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,11 +2,11 @@
 extern crate criterion;
 
 use criterion::{BenchmarkId, Criterion};
-use rust_decimal::prelude::FromPrimitive;
 use sfv::{
     integer, key_ref, string_ref, token_ref, Decimal, Parser, RefDictSerializer, RefItemSerializer,
     RefListSerializer, SerializeValue,
 };
+use std::convert::TryFrom;
 
 criterion_main!(parsing, serializing, ref_serializing);
 
@@ -106,7 +106,7 @@ fn serializing_ref_item(c: &mut Criterion) {
         move |bench, &input| {
             bench.iter(|| {
                 let ser = RefItemSerializer::new();
-                ser.bare_item(input.as_bytes()).unwrap().finish()
+                ser.bare_item(input.as_bytes()).finish()
             });
         },
     );
@@ -117,27 +117,20 @@ fn serializing_ref_list(c: &mut Criterion) {
         bench.iter(|| {
             let ser = RefListSerializer::new();
             ser.bare_item(token_ref("a"))
-                .unwrap()
                 .bare_item(token_ref("abcdefghigklmnoprst"))
-                .unwrap()
                 .bare_item(integer(123456785686457))
-                .unwrap()
-                .bare_item(Decimal::from_f64(99999999999.999).unwrap())
-                .unwrap()
+                .bare_item(Decimal::try_from(99999999999.999).unwrap())
                 .open_inner_list()
                 .close_inner_list()
                 .open_inner_list()
                 .inner_list_bare_item(string_ref("somelongstringvalue"))
-                .unwrap()
                 .inner_list_bare_item(string_ref("anotherlongstringvalue"))
-                .unwrap()
                 .inner_list_parameter(
                     key_ref("key"),
                     "somever longstringvaluerepresentedasbytes".as_bytes(),
                 )
                 .unwrap()
                 .inner_list_bare_item(145)
-                .unwrap()
                 .close_inner_list()
                 .finish()
         });
@@ -149,16 +142,11 @@ fn serializing_ref_dict(c: &mut Criterion) {
         bench.iter(|| {
             RefDictSerializer::new()
                 .bare_item_member(key_ref("a"), true)
-                .unwrap()
                 .bare_item_member(key_ref("dict_key2"), token_ref("abcdefghigklmnoprst"))
-                .unwrap()
                 .bare_item_member(key_ref("dict_key3"), integer(123456785686457))
-                .unwrap()
                 .open_inner_list(key_ref("dict_key4"))
                 .inner_list_bare_item(string_ref("inner-list-member"))
-                .unwrap()
                 .inner_list_bare_item("inner-list-member".as_bytes())
-                .unwrap()
                 .close_inner_list()
                 .parameter(key_ref("key"), token_ref("aW5uZXItbGlzdC1wYXJhbWV0ZXJz"))
                 .unwrap()

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 use criterion::{BenchmarkId, Criterion};
 use rust_decimal::prelude::FromPrimitive;
 use sfv::{
-    integer, string_ref, token_ref, Decimal, Parser, RefDictSerializer, RefItemSerializer,
+    integer, key_ref, string_ref, token_ref, Decimal, Parser, RefDictSerializer, RefItemSerializer,
     RefListSerializer, SerializeValue,
 };
 
@@ -132,7 +132,7 @@ fn serializing_ref_list(c: &mut Criterion) {
                 .inner_list_bare_item(string_ref("anotherlongstringvalue"))
                 .unwrap()
                 .inner_list_parameter(
-                    "key",
+                    key_ref("key"),
                     "somever longstringvaluerepresentedasbytes".as_bytes(),
                 )
                 .unwrap()
@@ -148,20 +148,19 @@ fn serializing_ref_dict(c: &mut Criterion) {
     c.bench_function("serializing_ref_dict", move |bench| {
         bench.iter(|| {
             RefDictSerializer::new()
-                .bare_item_member("a", true)
+                .bare_item_member(key_ref("a"), true)
                 .unwrap()
-                .bare_item_member("dict_key2", token_ref("abcdefghigklmnoprst"))
+                .bare_item_member(key_ref("dict_key2"), token_ref("abcdefghigklmnoprst"))
                 .unwrap()
-                .bare_item_member("dict_key3", integer(123456785686457))
+                .bare_item_member(key_ref("dict_key3"), integer(123456785686457))
                 .unwrap()
-                .open_inner_list("dict_key4")
-                .unwrap()
+                .open_inner_list(key_ref("dict_key4"))
                 .inner_list_bare_item(string_ref("inner-list-member"))
                 .unwrap()
                 .inner_list_bare_item("inner-list-member".as_bytes())
                 .unwrap()
                 .close_inner_list()
-                .parameter("key", token_ref("aW5uZXItbGlzdC1wYXJhbWV0ZXJz"))
+                .parameter(key_ref("key"), token_ref("aW5uZXItbGlzdC1wYXJhbWV0ZXJz"))
                 .unwrap()
                 .finish()
         });

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,8 +4,8 @@ extern crate criterion;
 use criterion::{BenchmarkId, Criterion};
 use rust_decimal::prelude::FromPrimitive;
 use sfv::{
-    integer, Decimal, Parser, RefBareItem, RefDictSerializer, RefItemSerializer, RefListSerializer,
-    SerializeValue,
+    integer, token_ref, Decimal, Parser, RefBareItem, RefDictSerializer, RefItemSerializer,
+    RefListSerializer, SerializeValue,
 };
 
 criterion_main!(parsing, serializing, ref_serializing);
@@ -116,9 +116,9 @@ fn serializing_ref_list(c: &mut Criterion) {
     c.bench_function("serializing_ref_list", move |bench| {
         bench.iter(|| {
             let ser = RefListSerializer::new();
-            ser.bare_item(RefBareItem::Token("a"))
+            ser.bare_item(token_ref("a"))
                 .unwrap()
-                .bare_item(RefBareItem::Token("abcdefghigklmnoprst"))
+                .bare_item(token_ref("abcdefghigklmnoprst"))
                 .unwrap()
                 .bare_item(integer(123456785686457))
                 .unwrap()
@@ -150,7 +150,7 @@ fn serializing_ref_dict(c: &mut Criterion) {
             RefDictSerializer::new()
                 .bare_item_member("a", true)
                 .unwrap()
-                .bare_item_member("dict_key2", RefBareItem::Token("abcdefghigklmnoprst"))
+                .bare_item_member("dict_key2", token_ref("abcdefghigklmnoprst"))
                 .unwrap()
                 .bare_item_member("dict_key3", integer(123456785686457))
                 .unwrap()
@@ -161,7 +161,7 @@ fn serializing_ref_dict(c: &mut Criterion) {
                 .inner_list_bare_item("inner-list-member".as_bytes())
                 .unwrap()
                 .close_inner_list()
-                .parameter("key", RefBareItem::Token("aW5uZXItbGlzdC1wYXJhbWV0ZXJz"))
+                .parameter("key", token_ref("aW5uZXItbGlzdC1wYXJhbWV0ZXJz"))
                 .unwrap()
                 .finish()
         });

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 use criterion::{BenchmarkId, Criterion};
 use rust_decimal::prelude::FromPrimitive;
 use sfv::{
-    integer, token_ref, Decimal, Parser, RefBareItem, RefDictSerializer, RefItemSerializer,
+    integer, string_ref, token_ref, Decimal, Parser, RefDictSerializer, RefItemSerializer,
     RefListSerializer, SerializeValue,
 };
 
@@ -127,9 +127,9 @@ fn serializing_ref_list(c: &mut Criterion) {
                 .open_inner_list()
                 .close_inner_list()
                 .open_inner_list()
-                .inner_list_bare_item(RefBareItem::String("somelongstringvalue"))
+                .inner_list_bare_item(string_ref("somelongstringvalue"))
                 .unwrap()
-                .inner_list_bare_item(RefBareItem::String("anotherlongstringvalue"))
+                .inner_list_bare_item(string_ref("anotherlongstringvalue"))
                 .unwrap()
                 .inner_list_parameter(
                     "key",
@@ -156,7 +156,7 @@ fn serializing_ref_dict(c: &mut Criterion) {
                 .unwrap()
                 .open_inner_list("dict_key4")
                 .unwrap()
-                .inner_list_bare_item(RefBareItem::String("inner-list-member"))
+                .inner_list_bare_item(string_ref("inner-list-member"))
                 .unwrap()
                 .inner_list_bare_item("inner-list-member".as_bytes())
                 .unwrap()

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,8 +3,10 @@ extern crate criterion;
 
 use criterion::{BenchmarkId, Criterion};
 use rust_decimal::prelude::FromPrimitive;
-use sfv::{Decimal, Parser, SerializeValue};
-use sfv::{RefBareItem, RefDictSerializer, RefItemSerializer, RefListSerializer};
+use sfv::{
+    integer, Decimal, Parser, RefBareItem, RefDictSerializer, RefItemSerializer, RefListSerializer,
+    SerializeValue,
+};
 
 criterion_main!(parsing, serializing, ref_serializing);
 
@@ -118,7 +120,7 @@ fn serializing_ref_list(c: &mut Criterion) {
                 .unwrap()
                 .bare_item(RefBareItem::Token("abcdefghigklmnoprst"))
                 .unwrap()
-                .bare_item(123456785686457)
+                .bare_item(integer(123456785686457))
                 .unwrap()
                 .bare_item(Decimal::from_f64(99999999999.999).unwrap())
                 .unwrap()
@@ -150,7 +152,7 @@ fn serializing_ref_dict(c: &mut Criterion) {
                 .unwrap()
                 .bare_item_member("dict_key2", RefBareItem::Token("abcdefghigklmnoprst"))
                 .unwrap()
-                .bare_item_member("dict_key3", 123456785686457)
+                .bare_item_member("dict_key3", integer(123456785686457))
                 .unwrap()
                 .open_inner_list("dict_key4")
                 .unwrap()

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,7 @@ libfuzzer-sys = "0.4"
 
 [dependencies.sfv]
 path = ".."
+features = ["arbitrary"]
 
 [[bin]]
 name = "parse_dictionary"
@@ -30,6 +31,27 @@ bench = false
 [[bin]]
 name = "parse_item"
 path = "fuzz_targets/parse_item.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "roundtrip_item"
+path = "fuzz_targets/roundtrip_item.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "roundtrip_list"
+path = "fuzz_targets/roundtrip_list.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "roundtrip_dictionary"
+path = "fuzz_targets/roundtrip_dictionary.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/parse_dictionary.rs
+++ b/fuzz/fuzz_targets/parse_dictionary.rs
@@ -1,20 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use sfv::SerializeValue as _;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(dict) = sfv::Parser::from_bytes(data).parse_dictionary() {
-        let serialized = dict.serialize_value();
-        if dict.is_empty() {
-            assert!(serialized.is_err());
-        } else {
-            assert_eq!(
-                sfv::Parser::from_bytes(serialized.unwrap().as_bytes())
-                    .parse_dictionary()
-                    .unwrap(),
-                dict
-            );
-        }
-    }
+    let _ = sfv::Parser::from_bytes(data).parse_dictionary();
 });

--- a/fuzz/fuzz_targets/parse_item.rs
+++ b/fuzz/fuzz_targets/parse_item.rs
@@ -1,16 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use sfv::SerializeValue as _;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(item) = sfv::Parser::from_bytes(data).parse_item() {
-        let serialized = item.serialize_value().unwrap();
-        assert_eq!(
-            sfv::Parser::from_bytes(serialized.as_bytes())
-                .parse_item()
-                .unwrap(),
-            item
-        );
-    }
+    let _ = sfv::Parser::from_bytes(data).parse_item();
 });

--- a/fuzz/fuzz_targets/parse_list.rs
+++ b/fuzz/fuzz_targets/parse_list.rs
@@ -1,20 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use sfv::SerializeValue as _;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(list) = sfv::Parser::from_bytes(data).parse_list() {
-        let serialized = list.serialize_value();
-        if list.is_empty() {
-            assert!(serialized.is_err());
-        } else {
-            assert_eq!(
-                sfv::Parser::from_bytes(serialized.unwrap().as_bytes())
-                    .parse_list()
-                    .unwrap(),
-                list
-            );
-        }
-    }
+    let _ = sfv::Parser::from_bytes(data).parse_list();
 });

--- a/fuzz/fuzz_targets/roundtrip_dictionary.rs
+++ b/fuzz/fuzz_targets/roundtrip_dictionary.rs
@@ -1,0 +1,18 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use sfv::SerializeValue as _;
+
+fuzz_target!(|dict: sfv::Dictionary| {
+    let serialized = dict.serialize_value();
+    if dict.is_empty() {
+        assert!(serialized.is_err());
+    } else {
+        assert_eq!(
+            sfv::Parser::from_bytes(serialized.unwrap().as_bytes())
+                .parse_dictionary()
+                .unwrap(),
+            dict
+        );
+    }
+});

--- a/fuzz/fuzz_targets/roundtrip_item.rs
+++ b/fuzz/fuzz_targets/roundtrip_item.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use sfv::SerializeValue as _;
+
+fuzz_target!(|item: sfv::Item| {
+    let serialized = item.serialize_value().unwrap();
+    assert_eq!(
+        sfv::Parser::from_bytes(serialized.as_bytes())
+            .parse_item()
+            .unwrap(),
+        item
+    );
+});

--- a/fuzz/fuzz_targets/roundtrip_list.rs
+++ b/fuzz/fuzz_targets/roundtrip_list.rs
@@ -1,0 +1,18 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use sfv::SerializeValue as _;
+
+fuzz_target!(|list: sfv::List| {
+    let serialized = list.serialize_value();
+    if list.is_empty() {
+        assert!(serialized.is_err());
+    } else {
+        assert_eq!(
+            sfv::Parser::from_bytes(serialized.unwrap().as_bytes())
+                .parse_list()
+                .unwrap(),
+            list,
+        );
+    }
+});

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -8,6 +8,7 @@ use std::fmt;
 ///
 /// [decimal]: <https://httpwg.org/specs/rfc8941.html#decimal>
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Decimal(Integer);
 
 impl Decimal {

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -121,6 +121,20 @@ impl TryFrom<i128> for Decimal {
     }
 }
 
+impl TryFrom<isize> for Decimal {
+    type Error = DecimalError;
+
+    fn try_from(v: isize) -> Result<Decimal, DecimalError> {
+        match v.checked_mul(1000) {
+            None => Err(DecimalError::OutOfRange),
+            Some(v) => match Integer::try_from(v) {
+                Ok(v) => Ok(Decimal(v)),
+                Err(_) => Err(DecimalError::OutOfRange),
+            },
+        }
+    }
+}
+
 impl From<u8> for Decimal {
     fn from(v: u8) -> Decimal {
         Self(Integer::from(v as u16 * 1000))
@@ -157,6 +171,20 @@ impl TryFrom<u128> for Decimal {
     type Error = DecimalError;
 
     fn try_from(v: u128) -> Result<Decimal, DecimalError> {
+        match v.checked_mul(1000) {
+            None => Err(DecimalError::OutOfRange),
+            Some(v) => match Integer::try_from(v) {
+                Ok(v) => Ok(Decimal(v)),
+                Err(_) => Err(DecimalError::OutOfRange),
+            },
+        }
+    }
+}
+
+impl TryFrom<usize> for Decimal {
+    type Error = DecimalError;
+
+    fn try_from(v: usize) -> Result<Decimal, DecimalError> {
         match v.checked_mul(1000) {
             None => Err(DecimalError::OutOfRange),
             Some(v) => match Integer::try_from(v) {
@@ -213,5 +241,13 @@ impl TryFrom<f64> for Decimal {
             Ok(v) => Ok(Decimal(v)),
             Err(_) => Err(DecimalError::OutOfRange),
         }
+    }
+}
+
+impl TryFrom<Integer> for Decimal {
+    type Error = DecimalError;
+
+    fn try_from(v: Integer) -> Result<Decimal, DecimalError> {
+        i64::from(v).try_into()
     }
 }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1,0 +1,216 @@
+use crate::Integer;
+use std::convert::{TryFrom, TryInto};
+use std::fmt;
+
+/// A structured field value [decimal].
+///
+/// Decimals have 12 digits of integer precision and 3 digits of fractional precision.
+///
+/// [decimal]: <https://httpwg.org/specs/rfc8941.html#decimal>
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Decimal(Integer);
+
+impl Decimal {
+    /// The minimum value for a parsed or serialized decimal: `-999_999_999_999.999`.
+    pub const MIN: Self = Self(Integer::MIN);
+
+    /// The maximum value for a parsed or serialized decimal: `999_999_999_999.999`.
+    pub const MAX: Self = Self(Integer::MAX);
+
+    /// `0.0`.
+    pub const ZERO: Self = Self(Integer::ZERO);
+
+    /// Returns the decimal as an integer multiplied by 1000.
+    ///
+    /// The conversion is guaranteed to be precise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::convert::TryFrom;
+    ///
+    /// let decimal = sfv::Decimal::try_from(1.234).unwrap();
+    /// assert_eq!(i64::from(decimal.as_integer_scaled_1000()), 1234);
+    /// ````
+    pub fn as_integer_scaled_1000(&self) -> Integer {
+        self.0
+    }
+
+    /// Creates a decimal from an integer multiplied by 1000.
+    ///
+    /// The conversion is guaranteed to be precise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let decimal = sfv::Decimal::from_integer_scaled_1000(sfv::integer(1234));
+    /// assert_eq!(f64::from(decimal), 1.234);
+    /// ````
+    pub const fn from_integer_scaled_1000(v: Integer) -> Self {
+        Self(v)
+    }
+}
+
+impl fmt::Display for Decimal {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let v = i64::from(self.as_integer_scaled_1000());
+
+        if v == 0 {
+            return f.write_str("0.0");
+        }
+
+        let sign = if v < 0 { "-" } else { "" };
+        let v = v.abs();
+        let i_part = v / 1000;
+        let f_part = v % 1000;
+
+        if f_part % 100 == 0 {
+            write!(f, "{}{}.{}", sign, i_part, f_part / 100)
+        } else if f_part % 10 == 0 {
+            write!(f, "{}{}.{:02}", sign, i_part, f_part / 10)
+        } else {
+            write!(f, "{}{}.{:03}", sign, i_part, f_part)
+        }
+    }
+}
+
+impl From<i8> for Decimal {
+    fn from(v: i8) -> Decimal {
+        Self(Integer::from(v as i16 * 1000))
+    }
+}
+
+impl From<i16> for Decimal {
+    fn from(v: i16) -> Decimal {
+        Self(Integer::from(v as i32 * 1000))
+    }
+}
+
+impl From<i32> for Decimal {
+    fn from(v: i32) -> Decimal {
+        Self(Integer::try_from(v as i64 * 1000).unwrap())
+    }
+}
+
+impl TryFrom<i64> for Decimal {
+    type Error = DecimalError;
+
+    fn try_from(v: i64) -> Result<Decimal, DecimalError> {
+        match v.checked_mul(1000) {
+            None => Err(DecimalError::OutOfRange),
+            Some(v) => match Integer::try_from(v) {
+                Ok(v) => Ok(Decimal(v)),
+                Err(_) => Err(DecimalError::OutOfRange),
+            },
+        }
+    }
+}
+
+impl TryFrom<i128> for Decimal {
+    type Error = DecimalError;
+
+    fn try_from(v: i128) -> Result<Decimal, DecimalError> {
+        match v.checked_mul(1000) {
+            None => Err(DecimalError::OutOfRange),
+            Some(v) => match Integer::try_from(v) {
+                Ok(v) => Ok(Decimal(v)),
+                Err(_) => Err(DecimalError::OutOfRange),
+            },
+        }
+    }
+}
+
+impl From<u8> for Decimal {
+    fn from(v: u8) -> Decimal {
+        Self(Integer::from(v as u16 * 1000))
+    }
+}
+
+impl From<u16> for Decimal {
+    fn from(v: u16) -> Decimal {
+        Self(Integer::from(v as u32 * 1000))
+    }
+}
+
+impl From<u32> for Decimal {
+    fn from(v: u32) -> Decimal {
+        Self(Integer::try_from(v as u64 * 1000).unwrap())
+    }
+}
+
+impl TryFrom<u64> for Decimal {
+    type Error = DecimalError;
+
+    fn try_from(v: u64) -> Result<Decimal, DecimalError> {
+        match v.checked_mul(1000) {
+            None => Err(DecimalError::OutOfRange),
+            Some(v) => match Integer::try_from(v) {
+                Ok(v) => Ok(Decimal(v)),
+                Err(_) => Err(DecimalError::OutOfRange),
+            },
+        }
+    }
+}
+
+impl TryFrom<u128> for Decimal {
+    type Error = DecimalError;
+
+    fn try_from(v: u128) -> Result<Decimal, DecimalError> {
+        match v.checked_mul(1000) {
+            None => Err(DecimalError::OutOfRange),
+            Some(v) => match Integer::try_from(v) {
+                Ok(v) => Ok(Decimal(v)),
+                Err(_) => Err(DecimalError::OutOfRange),
+            },
+        }
+    }
+}
+
+impl From<Decimal> for f64 {
+    fn from(v: Decimal) -> f64 {
+        let v = i64::from(v.as_integer_scaled_1000());
+        (v as f64) / 1000.0
+    }
+}
+
+/// An error that occurs when a value cannot be converted to a `Decimal`.
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DecimalError {
+    NaN,
+    OutOfRange,
+}
+
+impl fmt::Display for DecimalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            Self::NaN => "NaN",
+            Self::OutOfRange => "out of range",
+        })
+    }
+}
+
+impl std::error::Error for DecimalError {}
+
+impl TryFrom<f32> for Decimal {
+    type Error = DecimalError;
+
+    fn try_from(v: f32) -> Result<Decimal, DecimalError> {
+        (v as f64).try_into()
+    }
+}
+
+impl TryFrom<f64> for Decimal {
+    type Error = DecimalError;
+
+    fn try_from(v: f64) -> Result<Decimal, DecimalError> {
+        if v.is_nan() {
+            return Err(DecimalError::NaN);
+        }
+
+        match Integer::try_from((v * 1000.0).round_ties_even() as i64) {
+            Ok(v) => Ok(Decimal(v)),
+            Err(_) => Err(DecimalError::OutOfRange),
+        }
+    }
+}

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -15,6 +15,11 @@ impl Integer {
     /// The maximum value for a parsed or serialized integer: `999_999_999_999_999`.
     pub const MAX: Self = Self(999_999_999_999_999);
 
+    /// `0`.
+    ///
+    /// Equivalent to `Integer::constant(0)`.
+    pub const ZERO: Self = Self(0);
+
     /// Creates an `Integer`, panicking if the value is out of range.
     ///
     /// This method is intended to be called from `const` contexts in which the

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,4 +1,4 @@
-use crate::{BareItem, RefBareItem};
+use crate::GenericBareItem;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 
@@ -78,14 +78,9 @@ macro_rules! impl_conversion {
                 Integer(v.into())
             }
         }
-        impl From<$t> for BareItem {
-            fn from(v: $t) -> BareItem {
-                BareItem::Integer(v.into())
-            }
-        }
-        impl<'a> From<$t> for RefBareItem<'a> {
-            fn from(v: $t) -> RefBareItem<'a> {
-                RefBareItem::Integer(v.into())
+        impl<S, B, T> From<$t> for GenericBareItem<S, B, T> {
+            fn from(v: $t) -> Self {
+                Self::Integer(v.into())
             }
         }
     };
@@ -100,18 +95,11 @@ macro_rules! impl_conversion {
                 }
             }
         }
-        impl TryFrom<$t> for BareItem {
+        impl<S, B, T> TryFrom<$t> for GenericBareItem<S, B, T> {
             type Error = OutOfRangeError;
 
-            fn try_from(v: $t) -> Result<BareItem, OutOfRangeError> {
-                Integer::try_from(v).map(BareItem::Integer)
-            }
-        }
-        impl<'a> TryFrom<$t> for RefBareItem<'a> {
-            type Error = OutOfRangeError;
-
-            fn try_from(v: $t) -> Result<RefBareItem<'a>, OutOfRangeError> {
-                Integer::try_from(v).map(RefBareItem::Integer)
+            fn try_from(v: $t) -> Result<Self, OutOfRangeError> {
+                Integer::try_from(v).map(Self::Integer)
             }
         }
     };

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,0 +1,147 @@
+use crate::{BareItem, RefBareItem};
+use std::convert::{TryFrom, TryInto};
+use std::fmt;
+
+/// A structured field value [integer].
+///
+/// [integer]: <https://httpwg.org/specs/rfc8941.html#integer>
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Integer(i64);
+
+impl Integer {
+    /// The minimum value for a parsed or serialized integer: `-999_999_999_999_999`.
+    pub const MIN: Self = Self(-999_999_999_999_999);
+
+    /// The maximum value for a parsed or serialized integer: `999_999_999_999_999`.
+    pub const MAX: Self = Self(999_999_999_999_999);
+
+    /// Creates an `Integer`, panicking if the value is out of range.
+    ///
+    /// This method is intended to be called from `const` contexts in which the
+    /// value is known to be valid. Use [`TryFrom::try_from`] for non-panicking
+    /// conversions.
+    pub const fn constant(v: i64) -> Self {
+        if v >= Self::MIN.0 && v <= Self::MAX.0 {
+            Self(v)
+        } else {
+            panic!("out of range for Integer")
+        }
+    }
+}
+
+impl fmt::Display for Integer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+/// An error that occurs when a value is out of range.
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub struct OutOfRangeError;
+
+impl fmt::Display for OutOfRangeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("out of range")
+    }
+}
+
+impl std::error::Error for OutOfRangeError {}
+
+macro_rules! impl_conversions {
+    ($($t: ty: $from:ident => $into:ident,)+) => {
+        $(
+            impl_conversion!($from<$t>);
+            impl_conversion!($into<$t>);
+        )+
+    }
+}
+
+macro_rules! impl_conversion {
+    (From<$t: ty>) => {
+        impl From<$t> for Integer {
+            fn from(v: $t) -> Integer {
+                Integer(v.into())
+            }
+        }
+        impl From<$t> for BareItem {
+            fn from(v: $t) -> BareItem {
+                BareItem::Integer(v.into())
+            }
+        }
+        impl<'a> From<$t> for RefBareItem<'a> {
+            fn from(v: $t) -> RefBareItem<'a> {
+                RefBareItem::Integer(v.into())
+            }
+        }
+    };
+    (TryFrom<$t: ty>) => {
+        impl TryFrom<$t> for Integer {
+            type Error = OutOfRangeError;
+
+            fn try_from(v: $t) -> Result<Integer, OutOfRangeError> {
+                match i64::try_from(v) {
+                    Ok(v) if (Integer::MIN.0..=Integer::MAX.0).contains(&v) => Ok(Integer(v)),
+                    _ => Err(OutOfRangeError),
+                }
+            }
+        }
+        impl TryFrom<$t> for BareItem {
+            type Error = OutOfRangeError;
+
+            fn try_from(v: $t) -> Result<BareItem, OutOfRangeError> {
+                Integer::try_from(v).map(BareItem::Integer)
+            }
+        }
+        impl<'a> TryFrom<$t> for RefBareItem<'a> {
+            type Error = OutOfRangeError;
+
+            fn try_from(v: $t) -> Result<RefBareItem<'a>, OutOfRangeError> {
+                Integer::try_from(v).map(RefBareItem::Integer)
+            }
+        }
+    };
+    (Into<$t: ty>) => {
+        impl From<Integer> for $t {
+            fn from(v: Integer) -> $t {
+                v.0.into()
+            }
+        }
+    };
+    (TryInto<$t: ty>) => {
+        impl TryFrom<Integer> for $t {
+            type Error = OutOfRangeError;
+
+            fn try_from(v: Integer) -> Result<$t, OutOfRangeError> {
+                v.0.try_into().map_err(|_| OutOfRangeError)
+            }
+        }
+    };
+}
+
+impl_conversions! {
+    i8: From => TryInto,
+    i16: From => TryInto,
+    i32: From => TryInto,
+    i64: TryFrom => Into,
+    i128: TryFrom => Into,
+    isize: TryFrom => TryInto,
+
+    u8: From => TryInto,
+    u16: From => TryInto,
+    u32: From => TryInto,
+    u64: TryFrom => TryInto,
+    u128: TryFrom => TryInto,
+    usize: TryFrom => TryInto,
+}
+
+/// Creates an `Integer`, panicking if the value is out of range.
+///
+/// This is a convenience free function for [`Integer::constant`].
+///
+/// This method is intended to be called from `const` contexts in which the
+/// value is known to be valid. Use [`TryFrom::try_from`] for non-panicking
+/// conversions.
+pub const fn integer(v: i64) -> Integer {
+    Integer::constant(v)
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -85,6 +85,13 @@ impl KeyRef {
         Ok(Self::cast(v))
     }
 
+    // Like `from_str`, but assumes that the contents of the string have already
+    // been validated as a key.
+    pub(crate) fn from_validated_str(v: &str) -> &Self {
+        debug_assert!(validate(v.as_bytes()).is_ok());
+        Self::cast(v)
+    }
+
     /// Creates a `&KeyRef`, panicking if the value is invalid.
     ///
     /// This method is intended to be called from `const` contexts in which the

--- a/src/key.rs
+++ b/src/key.rs
@@ -122,6 +122,10 @@ impl ToOwned for KeyRef {
     fn to_owned(&self) -> Key {
         Key(self.0.to_owned())
     }
+
+    fn clone_into(&self, target: &mut Key) {
+        self.0.clone_into(&mut target.0);
+    }
 }
 
 impl Borrow<KeyRef> for Key {

--- a/src/key.rs
+++ b/src/key.rs
@@ -217,3 +217,25 @@ impl Borrow<str> for KeyRef {
         self.as_str()
     }
 }
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for &'a KeyRef {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        KeyRef::from_str(<&str>::arbitrary(u)?).map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (1, None)
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Key {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        <&KeyRef>::arbitrary(u).map(ToOwned::to_owned)
+    }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (1, None)
+    }
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -79,6 +79,7 @@ impl KeyRef {
     const fn cast(v: &str) -> &Self;
 
     /// Creates a `&KeyRef` from a `&str`.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(v: &str) -> Result<&Self, KeyError> {
         validate(v.as_bytes())?;
         Ok(Self::cast(v))

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,0 +1,219 @@
+use crate::utils;
+
+use std::borrow::Borrow;
+use std::convert::TryFrom;
+use std::fmt;
+
+/// An owned structured field value [key].
+///
+/// Keys must match the following regular expression:
+///
+/// ```re
+/// ^[A-Za-z*][A-Za-z*0-9!#$%&'+\-.^_`|~]*$
+/// ```
+///
+/// [key]: <https://httpwg.org/specs/rfc8941.html#key>
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Key(String);
+
+/// A borrowed structured field value [key].
+///
+/// Keys must match the following regular expression:
+///
+/// ```re
+/// ^[A-Za-z*][A-Za-z*0-9!#$%&'+\-.^_`|~]*$
+/// ```
+///
+/// This type is to [`Key`] as [`str`] is to [`String`].
+///
+/// [key]: <https://httpwg.org/specs/rfc8941.html#key>
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, ref_cast::RefCastCustom)]
+#[repr(transparent)]
+pub struct KeyRef(str);
+
+/// An error produced during conversion to a key.
+#[derive(Debug)]
+pub struct KeyError {
+    byte_index: Option<usize>,
+}
+
+impl fmt::Display for KeyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(byte_index) = self.byte_index {
+            write!(f, "invalid character for key at byte index {}", byte_index)
+        } else {
+            f.write_str("key cannot be empty")
+        }
+    }
+}
+
+impl std::error::Error for KeyError {}
+
+const fn validate(v: &[u8]) -> Result<(), KeyError> {
+    if v.is_empty() {
+        return Err(KeyError { byte_index: None });
+    }
+
+    if !utils::is_allowed_start_key_char(v[0]) {
+        return Err(KeyError {
+            byte_index: Some(0),
+        });
+    }
+
+    let mut index = 1;
+
+    while index < v.len() {
+        if !utils::is_allowed_inner_key_char(v[index]) {
+            return Err(KeyError {
+                byte_index: Some(index),
+            });
+        }
+        index += 1;
+    }
+
+    Ok(())
+}
+
+impl KeyRef {
+    #[ref_cast::ref_cast_custom]
+    const fn cast(v: &str) -> &Self;
+
+    /// Creates a `&KeyRef` from a `&str`.
+    pub fn from_str(v: &str) -> Result<&Self, KeyError> {
+        validate(v.as_bytes())?;
+        Ok(Self::cast(v))
+    }
+
+    /// Creates a `&KeyRef`, panicking if the value is invalid.
+    ///
+    /// This method is intended to be called from `const` contexts in which the
+    /// value is known to be valid. Use [`KeyRef::from_str`] for non-panicking
+    /// conversions.
+    pub const fn constant(v: &str) -> &Self {
+        match validate(v.as_bytes()) {
+            Ok(_) => Self::cast(v),
+            Err(err) => {
+                if err.byte_index.is_none() {
+                    panic!("key cannot be empty")
+                } else {
+                    panic!("invalid character for key")
+                }
+            }
+        }
+    }
+
+    /// Returns the key as a `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl ToOwned for KeyRef {
+    type Owned = Key;
+
+    fn to_owned(&self) -> Key {
+        Key(self.0.to_owned())
+    }
+}
+
+impl Borrow<KeyRef> for Key {
+    fn borrow(&self) -> &KeyRef {
+        self
+    }
+}
+
+impl std::ops::Deref for Key {
+    type Target = KeyRef;
+
+    fn deref(&self) -> &KeyRef {
+        KeyRef::cast(&self.0)
+    }
+}
+
+impl From<Key> for String {
+    fn from(v: Key) -> String {
+        v.0
+    }
+}
+
+impl TryFrom<String> for Key {
+    type Error = KeyError;
+
+    fn try_from(v: String) -> Result<Key, KeyError> {
+        validate(v.as_bytes())?;
+        Ok(Key(v))
+    }
+}
+
+impl Key {
+    /// Creates a `Key` from a `String`.
+    ///
+    /// Returns the original value if the conversion failed.
+    pub fn from_string(v: String) -> Result<Self, (KeyError, String)> {
+        match validate(v.as_bytes()) {
+            Ok(_) => Ok(Self(v)),
+            Err(err) => Err((err, v)),
+        }
+    }
+}
+
+/// Creates a `&KeyRef`, panicking if the value is invalid.
+///
+/// This is a convenience free function for [`KeyRef::constant`].
+///
+/// This method is intended to be called from `const` contexts in which the
+/// value is known to be valid. Use [`KeyRef::from_str`] for non-panicking
+/// conversions.
+pub const fn key_ref(v: &str) -> &KeyRef {
+    KeyRef::constant(v)
+}
+
+impl fmt::Display for KeyRef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Display for Key {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <KeyRef as fmt::Display>::fmt(self, f)
+    }
+}
+
+macro_rules! impl_eq {
+    ($a: ty, $b: ty) => {
+        impl PartialEq<$a> for $b {
+            fn eq(&self, other: &$a) -> bool {
+                <KeyRef as PartialEq>::eq(self, other)
+            }
+        }
+        impl PartialEq<$b> for $a {
+            fn eq(&self, other: &$b) -> bool {
+                <KeyRef as PartialEq>::eq(self, other)
+            }
+        }
+    };
+}
+
+impl_eq!(Key, KeyRef);
+impl_eq!(Key, &KeyRef);
+
+impl<'a> TryFrom<&'a str> for &'a KeyRef {
+    type Error = KeyError;
+
+    fn try_from(v: &'a str) -> Result<&'a KeyRef, KeyError> {
+        KeyRef::from_str(v)
+    }
+}
+
+impl Borrow<str> for Key {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for KeyRef {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,3 +564,15 @@ impl<'a> From<&'a StringRef> for RefBareItem<'a> {
         RefBareItem::String(val)
     }
 }
+
+impl PartialEq<BareItem> for RefBareItem<'_> {
+    fn eq(&self, other: &BareItem) -> bool {
+        *self == RefBareItem::from(other)
+    }
+}
+
+impl<'a> PartialEq<RefBareItem<'a>> for BareItem {
+    fn eq(&self, other: &RefBareItem<'a>) -> bool {
+        RefBareItem::from(self) == *other
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,18 +107,18 @@ assert_eq!(str_item.serialize_value().unwrap(), r#""foo""#);
 
 Creates `Item` field value with parameters:
 ```
-use sfv::{Item, BareItem, SerializeValue, Parameters, Decimal, FromPrimitive};
+use sfv::{key_ref, Item, BareItem, SerializeValue, Parameters, Decimal, FromPrimitive};
 
 let mut params = Parameters::new();
 let decimal = Decimal::from_f64(13.45655).unwrap();
-params.insert("key".into(), BareItem::Decimal(decimal));
+params.insert(key_ref("key").to_owned(), BareItem::Decimal(decimal));
 let int_item = Item::with_params(99, params);
 assert_eq!(int_item.serialize_value().unwrap(), "99;key=13.457");
 ```
 
 Creates `List` field value with `Item` and parametrized `InnerList` as members:
 ```
-use sfv::{string_ref, token_ref, Item, BareItem, InnerList, List, SerializeValue, Parameters};
+use sfv::{key_ref, string_ref, token_ref, Item, BareItem, InnerList, List, SerializeValue, Parameters};
 
 let tok_item = BareItem::Token(token_ref("tok").to_owned());
 
@@ -127,12 +127,12 @@ let str_item = Item::new(string_ref("foo").to_owned());
 
 // Creates InnerList members.
 let mut int_item_params = Parameters::new();
-int_item_params.insert("key".into(), BareItem::Boolean(false));
+int_item_params.insert(key_ref("key").to_owned(), BareItem::Boolean(false));
 let int_item = Item::with_params(99, int_item_params);
 
 // Creates InnerList.
 let mut inner_list_params = Parameters::new();
-inner_list_params.insert("bar".into(), BareItem::Boolean(true));
+inner_list_params.insert(key_ref("bar").to_owned(), BareItem::Boolean(true));
 let inner_list = InnerList::with_params(vec![int_item, str_item], inner_list_params);
 
 
@@ -145,16 +145,16 @@ assert_eq!(
 
 Creates `Dictionary` field value:
 ```
-use sfv::{string_ref, Parser, Item, SerializeValue, Dictionary};
+use sfv::{key_ref, string_ref, Parser, Item, SerializeValue, Dictionary};
 
 let member_value1 = Item::new(string_ref("apple").to_owned());
 let member_value2 = Item::new(true);
 let member_value3 = Item::new(false);
 
 let mut dict = Dictionary::new();
-dict.insert("key1".into(), member_value1.into());
-dict.insert("key2".into(), member_value2.into());
-dict.insert("key3".into(), member_value3.into());
+dict.insert(key_ref("key1").to_owned(), member_value1.into());
+dict.insert(key_ref("key2").to_owned(), member_value2.into());
+dict.insert(key_ref("key3").to_owned(), member_value3.into());
 
 assert_eq!(
     dict.serialize_value().unwrap(),
@@ -166,6 +166,7 @@ assert_eq!(
 
 mod error;
 mod integer;
+mod key;
 mod parser;
 mod ref_serializer;
 mod serializer;
@@ -176,6 +177,8 @@ mod utils;
 #[cfg(test)]
 mod test_integer;
 #[cfg(test)]
+mod test_key;
+#[cfg(test)]
 mod test_parser;
 #[cfg(test)]
 mod test_serializer;
@@ -185,7 +188,6 @@ mod test_string;
 mod test_token;
 
 use indexmap::IndexMap;
-use std::string::String as StdString;
 
 pub use rust_decimal::{
     prelude::{FromPrimitive, FromStr},
@@ -194,6 +196,7 @@ pub use rust_decimal::{
 
 pub use error::Error;
 pub use integer::{integer, Integer, OutOfRangeError};
+pub use key::{key_ref, Key, KeyError, KeyRef};
 pub use parser::{ParseMore, Parser};
 pub use ref_serializer::{
     RefDictSerializer, RefInnerListSerializer, RefItemSerializer, RefListSerializer,
@@ -240,7 +243,7 @@ impl Item {
 // dict-member    = member-name [ "=" member-value ]
 // member-name    = key
 // member-value   = sf-item / inner-list
-pub type Dictionary = IndexMap<StdString, ListEntry>;
+pub type Dictionary = IndexMap<Key, ListEntry>;
 
 /// Represents `List` type structured field value.
 // sf-list       = list-member *( OWS "," OWS list-member )
@@ -255,7 +258,7 @@ pub type List = Vec<ListEntry>;
 //                 *( lcalpha / DIGIT / "_" / "-" / "." / "*" )
 // lcalpha       = %x61-7A ; a-z
 // param-value   = bare-item
-pub type Parameters = IndexMap<StdString, BareItem>;
+pub type Parameters = IndexMap<Key, BareItem>;
 
 /// Represents a member of `List` or `Dictionary` structured field value.
 #[derive(Debug, PartialEq, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ Creates `Item` with empty parameters:
 ```
 use sfv::{string_ref, Item, SerializeValue};
 
-let str_item = Item::new(string_ref("foo").to_owned());
+let str_item = Item::new(string_ref("foo"));
 assert_eq!(str_item.serialize_value().unwrap(), r#""foo""#);
 ```
 
@@ -124,7 +124,7 @@ use sfv::{key_ref, string_ref, token_ref, Item, BareItem, InnerList, List, Seria
 let tok_item = BareItem::Token(token_ref("tok").to_owned());
 
 // Creates Item.
-let str_item = Item::new(string_ref("foo").to_owned());
+let str_item = Item::new(string_ref("foo"));
 
 // Creates InnerList members.
 let mut int_item_params = Parameters::new();
@@ -148,7 +148,7 @@ Creates `Dictionary` field value:
 ```
 use sfv::{key_ref, string_ref, Parser, Item, SerializeValue, Dictionary};
 
-let member_value1 = Item::new(string_ref("apple").to_owned());
+let member_value1 = Item::new(string_ref("apple"));
 let member_value2 = Item::new(true);
 let member_value3 = Item::new(false);
 
@@ -377,7 +377,7 @@ impl BareItem {
     /// If `BareItem` is a `ByteSeq`, returns `&Vec<u8>`, otherwise returns `None`.
     /// ```
     /// # use sfv::BareItem;
-    /// let bare_item = BareItem::ByteSeq("foo".to_owned().into_bytes());
+    /// let bare_item = BareItem::ByteSeq(b"foo".to_vec());
     /// assert_eq!(bare_item.as_byte_seq().unwrap().as_slice(), "foo".as_bytes());
     /// ```
     pub fn as_byte_seq(&self) -> Option<&Vec<u8>> {
@@ -454,6 +454,24 @@ impl From<Token> for BareItem {
 impl From<String> for BareItem {
     fn from(val: String) -> BareItem {
         BareItem::String(val)
+    }
+}
+
+impl<'a> From<&'a [u8]> for BareItem {
+    fn from(val: &'a [u8]) -> BareItem {
+        BareItem::ByteSeq(val.to_owned())
+    }
+}
+
+impl<'a> From<&'a TokenRef> for BareItem {
+    fn from(val: &'a TokenRef) -> BareItem {
+        BareItem::Token(val.to_owned())
+    }
+}
+
+impl<'a> From<&'a StringRef> for BareItem {
+    fn from(val: &'a StringRef) -> BareItem {
+        BareItem::String(val.to_owned())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,10 +107,11 @@ assert_eq!(str_item.serialize_value().unwrap(), r#""foo""#);
 
 Creates `Item` field value with parameters:
 ```
-use sfv::{key_ref, Item, BareItem, SerializeValue, Parameters, Decimal, FromPrimitive};
+use std::convert::TryFrom;
+use sfv::{key_ref, Item, BareItem, SerializeValue, Parameters, Decimal};
 
 let mut params = Parameters::new();
-let decimal = Decimal::from_f64(13.45655).unwrap();
+let decimal = Decimal::try_from(13.45655).unwrap();
 params.insert(key_ref("key").to_owned(), BareItem::Decimal(decimal));
 let int_item = Item::with_params(99, params);
 assert_eq!(int_item.serialize_value().unwrap(), "99;key=13.457");
@@ -164,6 +165,7 @@ assert_eq!(
 ```
 */
 
+mod decimal;
 mod error;
 mod integer;
 mod key;
@@ -174,6 +176,8 @@ mod string;
 mod token;
 mod utils;
 
+#[cfg(test)]
+mod test_decimal;
 #[cfg(test)]
 mod test_integer;
 #[cfg(test)]
@@ -189,11 +193,7 @@ mod test_token;
 
 use indexmap::IndexMap;
 
-pub use rust_decimal::{
-    prelude::{FromPrimitive, FromStr},
-    Decimal,
-};
-
+pub use decimal::{Decimal, DecimalError};
 pub use error::Error;
 pub use integer::{integer, Integer, OutOfRangeError};
 pub use key::{key_ref, Key, KeyError, KeyRef};
@@ -334,8 +334,9 @@ pub enum BareItem {
 impl BareItem {
     /// If `BareItem` is a decimal, returns `Decimal`, otherwise returns `None`.
     /// ```
-    /// # use sfv::{BareItem, Decimal, FromPrimitive};
-    /// let decimal_number = Decimal::from_f64(415.566).unwrap();
+    /// # use std::convert::TryFrom;
+    /// # use sfv::{BareItem, Decimal};
+    /// let decimal_number = Decimal::try_from(415.566).unwrap();
     /// let bare_item: BareItem = decimal_number.into();
     /// assert_eq!(bare_item.as_decimal().unwrap(), decimal_number);
     /// ```
@@ -423,8 +424,9 @@ impl From<bool> for BareItem {
 impl From<Decimal> for BareItem {
     /// Converts `Decimal` into `BareItem::Decimal`.
     /// ```
-    /// # use sfv::{BareItem, Decimal, FromPrimitive};
-    /// let decimal_number = Decimal::from_f64(48.01).unwrap();
+    /// # use std::convert::TryFrom;
+    /// # use sfv::{BareItem, Decimal};
+    /// let decimal_number = Decimal::try_from(48.01).unwrap();
     /// let bare_item: BareItem = decimal_number.into();
     /// assert_eq!(bare_item.as_decimal().unwrap(), decimal_number);
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,13 +321,15 @@ impl InnerList {
 }
 
 /// An abstraction over multiple kinds of ownership of a bare item.
+///
+/// In general most users will be interested in:
+/// - [`BareItem`], for completely owned data
+/// - [`RefBareItem`], for completely borrowed data
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum GenericBareItem<S, B, T> {
-    /// Decimal number
     // sf-decimal  = ["-"] 1*12DIGIT "." 1*3DIGIT
     Decimal(Decimal),
-    /// Integer number
     // sf-integer = ["-"] 1*15DIGIT
     Integer(Integer),
     // sf-string = DQUOTE *chr DQUOTE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,7 @@ type SFVResult<T> = std::result::Result<T, Error>;
 // bare-item = sf-integer / sf-decimal / sf-string / sf-token
 //             / sf-binary / sf-boolean
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Item {
     /// Value of `Item`.
     pub bare_item: BareItem,
@@ -262,6 +263,7 @@ pub type Parameters = IndexMap<Key, BareItem>;
 
 /// Represents a member of `List` or `Dictionary` structured field value.
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ListEntry {
     /// Member of `Item` type.
     Item(Item),
@@ -285,6 +287,7 @@ impl From<InnerList> for ListEntry {
 // inner-list    = "(" *SP [ sf-item *( 1*SP sf-item ) *SP ] ")"
 //                 parameters
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InnerList {
     /// `Items` that `InnerList` contains. Can be empty.
     pub items: Vec<Item>,
@@ -309,6 +312,7 @@ impl InnerList {
 
 /// `BareItem` type is used to construct `Items` or `Parameters` values.
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum BareItem {
     /// Decimal number
     // sf-decimal  = ["-"] 1*12DIGIT "." 1*3DIGIT
@@ -461,6 +465,7 @@ pub(crate) enum Num {
 
 /// Similar to `BareItem`, but used to serialize values via `RefItemSerializer`, `RefListSerializer`, `RefDictSerializer`.
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum RefBareItem<'a> {
     Integer(Integer),
     Decimal(Decimal),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,70 +98,80 @@ match dict.get("u") {
 ### Structured Field Value Construction and Serialization
 Creates `Item` with empty parameters:
 ```
-use sfv::{string_ref, Item, SerializeValue};
+use sfv::{StringRef, Item, SerializeValue};
 
-let str_item = Item::new(string_ref("foo"));
-assert_eq!(str_item.serialize_value().unwrap(), r#""foo""#);
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let str_item = Item::new(StringRef::from_str("foo")?);
+assert_eq!(str_item.serialize_value()?, r#""foo""#);
+# Ok(())
+# }
 ```
 
 
 Creates `Item` field value with parameters:
 ```
 use std::convert::TryFrom;
-use sfv::{key_ref, Item, BareItem, SerializeValue, Parameters, Decimal};
+use sfv::{KeyRef, Item, BareItem, SerializeValue, Parameters, Decimal};
 
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 let mut params = Parameters::new();
-let decimal = Decimal::try_from(13.45655).unwrap();
-params.insert(key_ref("key").to_owned(), BareItem::Decimal(decimal));
+let decimal = Decimal::try_from(13.45655)?;
+params.insert(KeyRef::from_str("key")?.to_owned(), BareItem::Decimal(decimal));
 let int_item = Item::with_params(99, params);
-assert_eq!(int_item.serialize_value().unwrap(), "99;key=13.457");
+assert_eq!(int_item.serialize_value()?, "99;key=13.457");
+# Ok(())
+# }
 ```
 
 Creates `List` field value with `Item` and parametrized `InnerList` as members:
 ```
-use sfv::{key_ref, string_ref, token_ref, Item, BareItem, InnerList, List, SerializeValue, Parameters};
+use sfv::{KeyRef, StringRef, TokenRef, Item, BareItem, InnerList, List, SerializeValue, Parameters};
 
-let tok_item = BareItem::Token(token_ref("tok").to_owned());
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let tok_item = BareItem::Token(TokenRef::from_str("tok")?.to_owned());
 
 // Creates Item.
-let str_item = Item::new(string_ref("foo"));
+let str_item = Item::new(StringRef::from_str("foo")?);
 
 // Creates InnerList members.
 let mut int_item_params = Parameters::new();
-int_item_params.insert(key_ref("key").to_owned(), BareItem::Boolean(false));
+int_item_params.insert(KeyRef::from_str("key")?.to_owned(), BareItem::Boolean(false));
 let int_item = Item::with_params(99, int_item_params);
 
 // Creates InnerList.
 let mut inner_list_params = Parameters::new();
-inner_list_params.insert(key_ref("bar").to_owned(), BareItem::Boolean(true));
+inner_list_params.insert(KeyRef::from_str("bar")?.to_owned(), BareItem::Boolean(true));
 let inner_list = InnerList::with_params(vec![int_item, str_item], inner_list_params);
-
 
 let list: List = vec![Item::new(tok_item).into(), inner_list.into()];
 assert_eq!(
-    list.serialize_value().unwrap(),
+    list.serialize_value()?,
     r#"tok, (99;key=?0 "foo");bar"#
 );
+# Ok(())
+# }
 ```
 
 Creates `Dictionary` field value:
 ```
-use sfv::{key_ref, string_ref, Parser, Item, SerializeValue, Dictionary};
+use sfv::{KeyRef, StringRef, Parser, Item, SerializeValue, Dictionary};
 
-let member_value1 = Item::new(string_ref("apple"));
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let member_value1 = Item::new(StringRef::from_str("apple")?.to_owned());
 let member_value2 = Item::new(true);
 let member_value3 = Item::new(false);
 
 let mut dict = Dictionary::new();
-dict.insert(key_ref("key1").to_owned(), member_value1.into());
-dict.insert(key_ref("key2").to_owned(), member_value2.into());
-dict.insert(key_ref("key3").to_owned(), member_value3.into());
+dict.insert(KeyRef::from_str("key1")?.to_owned(), member_value1.into());
+dict.insert(KeyRef::from_str("key2")?.to_owned(), member_value2.into());
+dict.insert(KeyRef::from_str("key3")?.to_owned(), member_value3.into());
 
 assert_eq!(
-    dict.serialize_value().unwrap(),
+    dict.serialize_value()?,
     r#"key1="apple", key2, key3=?0"#
 );
-
+# Ok(())
+# }
 ```
 */
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,10 @@
 use crate::utils;
 use crate::{
-    BareItem, Decimal, Dictionary, Error, InnerList, Item, List, ListEntry, Num, Parameters,
-    SFVResult,
+    BareItem, Decimal, Dictionary, Error, InnerList, Integer, Item, List, ListEntry, Num,
+    Parameters, SFVResult,
 };
+
+use std::convert::TryFrom;
 
 trait ParseValue {
     fn parse(parser: &mut Parser) -> SFVResult<Self>
@@ -442,7 +444,7 @@ impl<'a> Parser<'a> {
                     self.next();
                     magnitude = magnitude * 10 + char_to_i64(c);
                 }
-                _ => return Ok(Num::Integer(sign * magnitude)),
+                _ => return Ok(Num::Integer(Integer::try_from(sign * magnitude).unwrap())),
             }
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use crate::{
-    BareItem, Decimal, Dictionary, Error, InnerList, Integer, Item, List, ListEntry, Num,
+    BareItem, Decimal, Dictionary, Error, InnerList, Integer, Item, Key, List, ListEntry, Num,
     Parameters, SFVResult, String, Token,
 };
 
@@ -498,7 +498,7 @@ impl<'a> Parser<'a> {
         Ok(params)
     }
 
-    pub(crate) fn parse_key(&mut self) -> SFVResult<StdString> {
+    pub(crate) fn parse_key(&mut self) -> SFVResult<Key> {
         let mut output = StdString::new();
 
         match self.peek() {
@@ -515,7 +515,7 @@ impl<'a> Parser<'a> {
                     self.next();
                     output.push(c as char);
                 }
-                _ => return Ok(output),
+                _ => return Ok(Key::from_string(output).unwrap()),
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,10 +1,11 @@
 use crate::utils;
 use crate::{
     BareItem, Decimal, Dictionary, Error, InnerList, Integer, Item, List, ListEntry, Num,
-    Parameters, SFVResult, Token,
+    Parameters, SFVResult, String, Token,
 };
 
 use std::convert::TryFrom;
+use std::string::String as StdString;
 
 trait ParseValue {
     fn parse(parser: &mut Parser) -> SFVResult<Self>
@@ -310,12 +311,12 @@ impl<'a> Parser<'a> {
 
         self.next();
 
-        let mut output_string = String::new();
+        let mut output_string = StdString::new();
         while let Some(curr_char) = self.peek() {
             match curr_char {
                 b'"' => {
                     self.next();
-                    return Ok(output_string);
+                    return Ok(String::from_string(output_string).unwrap());
                 }
                 0x00..=0x1f | 0x7f..=0xff => {
                     return self.error("invalid string character");
@@ -343,7 +344,7 @@ impl<'a> Parser<'a> {
     pub(crate) fn parse_token(&mut self) -> SFVResult<Token> {
         // https://httpwg.org/specs/rfc8941.html#parse-token
 
-        let mut output_string = String::new();
+        let mut output_string = StdString::new();
 
         match self.peek() {
             Some(c) if utils::is_allowed_start_token_char(c) => {
@@ -497,8 +498,8 @@ impl<'a> Parser<'a> {
         Ok(params)
     }
 
-    pub(crate) fn parse_key(&mut self) -> SFVResult<String> {
-        let mut output = String::new();
+    pub(crate) fn parse_key(&mut self) -> SFVResult<StdString> {
+        let mut output = StdString::new();
 
         match self.peek() {
             Some(c) if utils::is_allowed_start_key_char(c) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use crate::utils;
 use crate::{
     BareItem, Decimal, Dictionary, Error, InnerList, Integer, Item, List, ListEntry, Num,
-    Parameters, SFVResult,
+    Parameters, SFVResult, Token,
 };
 
 use std::convert::TryFrom;
@@ -340,7 +340,7 @@ impl<'a> Parser<'a> {
         self.error("unterminated string")
     }
 
-    pub(crate) fn parse_token(&mut self) -> SFVResult<String> {
+    pub(crate) fn parse_token(&mut self) -> SFVResult<Token> {
         // https://httpwg.org/specs/rfc8941.html#parse-token
 
         let mut output_string = String::new();
@@ -359,7 +359,7 @@ impl<'a> Parser<'a> {
                     self.next();
                     output_string.push(c as char);
                 }
-                _ => return Ok(output_string),
+                _ => return Ok(Token::from_string(output_string).unwrap()),
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -449,26 +449,26 @@ impl<'a> Parser<'a> {
             }
         }
 
-        digits = 0;
+        magnitude *= 1000;
+        let mut scale = 100;
 
         while let Some(c @ b'0'..=b'9') = self.peek() {
-            if digits == 3 {
+            if scale == 0 {
                 return self.error("too many digits after decimal point");
             }
 
             self.next();
-            magnitude = magnitude * 10 + char_to_i64(c);
-            digits += 1;
+            magnitude += char_to_i64(c) * scale;
+            scale /= 10;
         }
 
-        if digits == 0 {
+        if scale == 100 {
             // Report the error at the position of the decimal itself, rather
             // than the next position.
             Err(Error::with_index("trailing decimal point", self.index - 1))
         } else {
-            Ok(Num::Decimal(Decimal::from_i128_with_scale(
-                (sign * magnitude) as i128,
-                digits,
+            Ok(Num::Decimal(Decimal::from_integer_scaled_1000(
+                Integer::try_from(sign * magnitude).unwrap(),
             )))
         }
     }

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -5,14 +5,17 @@ use std::borrow::BorrowMut;
 
 /// Serializes `Item` field value components incrementally.
 /// ```
-/// use sfv::{key_ref, RefItemSerializer};
+/// use sfv::{KeyRef, RefItemSerializer};
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let serialized_item = RefItemSerializer::new()
 ///     .bare_item(11)
-///     .parameter(key_ref("foo"), true)
+///     .parameter(KeyRef::from_str("foo")?, true)
 ///     .finish();
 ///
 /// assert_eq!(serialized_item, "11;foo");
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug)]
 pub struct RefItemSerializer<W> {
@@ -72,20 +75,19 @@ fn maybe_write_separator(buffer: &mut String, first: &mut bool) {
 
 /// Serializes `List` field value components incrementally.
 /// ```
-/// use sfv::{key_ref, string_ref, token_ref, RefListSerializer};
+/// use sfv::{KeyRef, StringRef, TokenRef, RefListSerializer};
 ///
-/// # fn main() -> Result<(), sfv::Error> {
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let serialized_list = RefListSerializer::new()
 ///     .bare_item(11)
-///     .parameter(key_ref("foo"), true)?
+///     .parameter(KeyRef::from_str("foo")?, true)?
 ///     .open_inner_list()
-///     .inner_list_bare_item(token_ref("abc"))
-///     .inner_list_parameter(key_ref("abc_param"), false)?
-///     .inner_list_bare_item(token_ref("def"))
+///     .inner_list_bare_item(TokenRef::from_str("abc")?)
+///     .inner_list_parameter(KeyRef::from_str("abc_param")?, false)?
+///     .inner_list_bare_item(TokenRef::from_str("def")?)
 ///     .close_inner_list()
-///     .parameter(key_ref("bar"), string_ref("val"))?
+///     .parameter(KeyRef::from_str("bar")?, StringRef::from_str("val")?)?
 ///     .finish()?;
-///
 /// assert_eq!(
 ///     serialized_list,
 ///     r#"11;foo, (abc;abc_param=?0 def);bar="val""#
@@ -154,22 +156,21 @@ impl<W: BorrowMut<String>> RefListSerializer<W> {
 
 /// Serializes `Dictionary` field value components incrementally.
 /// ```
-/// use sfv::{key_ref, string_ref, token_ref, Decimal, RefDictSerializer};
+/// use sfv::{KeyRef, StringRef, TokenRef, RefDictSerializer, Decimal};
 /// use std::convert::TryFrom;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let serialized_dict = RefDictSerializer::new()
-///    .bare_item_member(key_ref("member1"), 11)
-///    .parameter(key_ref("foo"), true)?
-///    .open_inner_list(key_ref("member2"))
-///    .inner_list_bare_item(token_ref("abc"))
-///    .inner_list_parameter(key_ref("abc_param"), false)?
-///    .inner_list_bare_item(token_ref("def"))
+///    .bare_item_member(KeyRef::from_str("member1")?, 11)
+///    .parameter(KeyRef::from_str("foo")?, true)?
+///    .open_inner_list(KeyRef::from_str("member2")?)
+///    .inner_list_bare_item(TokenRef::from_str("abc")?)
+///    .inner_list_parameter(KeyRef::from_str("abc_param")?, false)?
+///    .inner_list_bare_item(TokenRef::from_str("def")?)
 ///    .close_inner_list()
-///    .parameter(key_ref("bar"), string_ref("val"))?
-///    .bare_item_member(key_ref("member3"), Decimal::try_from(12.34566)?)
+///    .parameter(KeyRef::from_str("bar")?, StringRef::from_str("val")?)?
+///    .bare_item_member(KeyRef::from_str("member3")?, Decimal::try_from(12.34566)?)
 ///    .finish()?;
-///
 /// assert_eq!(
 ///    serialized_dict,
 ///    r#"member1=11;foo, member2=(abc;abc_param=?0 def);bar="val", member3=12.346"#

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -22,6 +22,12 @@ pub struct RefItemSerializer<W> {
     buffer: W,
 }
 
+impl Default for RefItemSerializer<String> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RefItemSerializer<String> {
     pub fn new() -> Self {
         Self {
@@ -99,6 +105,12 @@ fn maybe_write_separator(buffer: &mut String, first: &mut bool) {
 pub struct RefListSerializer<W> {
     buffer: W,
     first: bool,
+}
+
+impl Default for RefListSerializer<String> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RefListSerializer<String> {
@@ -182,6 +194,12 @@ impl<W: BorrowMut<String>> RefListSerializer<W> {
 pub struct RefDictSerializer<W> {
     buffer: W,
     first: bool,
+}
+
+impl Default for RefDictSerializer<String> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RefDictSerializer<String> {

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -79,7 +79,7 @@ fn maybe_write_separator(buffer: &mut String, first: &mut bool) {
 
 /// Serializes `List` field value components incrementally.
 /// ```
-/// use sfv::{token_ref, RefBareItem, RefListSerializer};
+/// use sfv::{string_ref, token_ref, RefListSerializer};
 ///
 /// # fn main() -> Result<(), sfv::Error> {
 /// let serialized_list = RefListSerializer::new()
@@ -90,7 +90,7 @@ fn maybe_write_separator(buffer: &mut String, first: &mut bool) {
 ///     .inner_list_parameter("abc_param", false)?
 ///     .inner_list_bare_item(token_ref("def"))?
 ///     .close_inner_list()
-///     .parameter("bar", RefBareItem::String("val"))?
+///     .parameter("bar", string_ref("val"))?
 ///     .finish()?;
 ///
 /// assert_eq!(
@@ -161,7 +161,7 @@ impl<W: BorrowMut<String>> RefListSerializer<W> {
 
 /// Serializes `Dictionary` field value components incrementally.
 /// ```
-/// use sfv::{token_ref, Decimal, FromPrimitive, RefBareItem, RefDictSerializer};
+/// use sfv::{string_ref, token_ref, Decimal, FromPrimitive, RefBareItem, RefDictSerializer};
 ///
 /// # fn main() -> Result<(), sfv::Error> {
 /// let serialized_dict = RefDictSerializer::new()
@@ -172,7 +172,7 @@ impl<W: BorrowMut<String>> RefListSerializer<W> {
 ///    .inner_list_parameter("abc_param", false)?
 ///    .inner_list_bare_item(token_ref("def"))?
 ///    .close_inner_list()
-///    .parameter("bar", RefBareItem::String("val"))?
+///    .parameter("bar", string_ref("val"))?
 ///    .bare_item_member(
 ///         "member3",
 ///         Decimal::from_f64(12.34566).unwrap(),
@@ -320,7 +320,7 @@ impl BufferHolder for String {
 #[cfg(test)]
 mod alternative_serializer_tests {
     use super::*;
-    use crate::{token_ref, Decimal, FromPrimitive};
+    use crate::{string_ref, token_ref, Decimal, FromPrimitive};
 
     #[test]
     fn test_fast_serialize_item() -> SFVResult<()> {
@@ -339,7 +339,7 @@ mod alternative_serializer_tests {
             .parameter("key1", true)?
             .parameter("key2", false)?
             .open_inner_list()
-            .inner_list_bare_item(RefBareItem::String("some_string"))?
+            .inner_list_bare_item(string_ref("some_string"))?
             .inner_list_bare_item(12)?
             .inner_list_parameter("inner-member-key", true)?
             .close_inner_list()
@@ -360,12 +360,12 @@ mod alternative_serializer_tests {
             .parameter("key2", false)?
             .bare_item_member("member2", true)?
             .parameter("key3", Decimal::from_f64(45.4586).unwrap())?
-            .parameter("key4", RefBareItem::String("str"))?
+            .parameter("key4", string_ref("str"))?
             .open_inner_list("key5")?
             .inner_list_bare_item(45)?
             .inner_list_bare_item(0)?
             .close_inner_list()
-            .bare_item_member("key6", RefBareItem::String("foo"))?
+            .bare_item_member("key6", string_ref("foo"))?
             .open_inner_list("key7")?
             .inner_list_bare_item("some_string".as_bytes())?
             .inner_list_bare_item("other_string".as_bytes())?

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -79,16 +79,16 @@ fn maybe_write_separator(buffer: &mut String, first: &mut bool) {
 
 /// Serializes `List` field value components incrementally.
 /// ```
-/// use sfv::{RefBareItem, RefListSerializer};
+/// use sfv::{token_ref, RefBareItem, RefListSerializer};
 ///
 /// # fn main() -> Result<(), sfv::Error> {
 /// let serialized_list = RefListSerializer::new()
 ///     .bare_item(11)?
 ///     .parameter("foo", true)?
 ///     .open_inner_list()
-///     .inner_list_bare_item(RefBareItem::Token("abc"))?
+///     .inner_list_bare_item(token_ref("abc"))?
 ///     .inner_list_parameter("abc_param", false)?
-///     .inner_list_bare_item(RefBareItem::Token("def"))?
+///     .inner_list_bare_item(token_ref("def"))?
 ///     .close_inner_list()
 ///     .parameter("bar", RefBareItem::String("val"))?
 ///     .finish()?;
@@ -161,16 +161,16 @@ impl<W: BorrowMut<String>> RefListSerializer<W> {
 
 /// Serializes `Dictionary` field value components incrementally.
 /// ```
-/// use sfv::{Decimal, FromPrimitive, RefBareItem, RefDictSerializer};
+/// use sfv::{token_ref, Decimal, FromPrimitive, RefBareItem, RefDictSerializer};
 ///
 /// # fn main() -> Result<(), sfv::Error> {
 /// let serialized_dict = RefDictSerializer::new()
 ///    .bare_item_member("member1", 11)?
 ///    .parameter("foo", true)?
 ///    .open_inner_list("member2")?
-///    .inner_list_bare_item(RefBareItem::Token("abc"))?
+///    .inner_list_bare_item(token_ref("abc"))?
 ///    .inner_list_parameter("abc_param", false)?
-///    .inner_list_bare_item(RefBareItem::Token("def"))?
+///    .inner_list_bare_item(token_ref("def"))?
 ///    .close_inner_list()
 ///    .parameter("bar", RefBareItem::String("val"))?
 ///    .bare_item_member(
@@ -320,12 +320,12 @@ impl BufferHolder for String {
 #[cfg(test)]
 mod alternative_serializer_tests {
     use super::*;
-    use crate::{Decimal, FromPrimitive};
+    use crate::{token_ref, Decimal, FromPrimitive};
 
     #[test]
     fn test_fast_serialize_item() -> SFVResult<()> {
         let output = RefItemSerializer::new()
-            .bare_item(RefBareItem::Token("hello"))?
+            .bare_item(token_ref("hello"))?
             .parameter("abc", true)?
             .finish();
         assert_eq!("hello;abc", output);
@@ -335,7 +335,7 @@ mod alternative_serializer_tests {
     #[test]
     fn test_fast_serialize_list() -> SFVResult<()> {
         let output = RefListSerializer::new()
-            .bare_item(RefBareItem::Token("hello"))?
+            .bare_item(token_ref("hello"))?
             .parameter("key1", true)?
             .parameter("key2", false)?
             .open_inner_list()
@@ -343,7 +343,7 @@ mod alternative_serializer_tests {
             .inner_list_bare_item(12)?
             .inner_list_parameter("inner-member-key", true)?
             .close_inner_list()
-            .parameter("inner-list-param", RefBareItem::Token("*"))?
+            .parameter("inner-list-param", token_ref("*"))?
             .finish()?;
         assert_eq!(
             "hello;key1;key2=?0, (\"some_string\" 12;inner-member-key);inner-list-param=*",
@@ -355,7 +355,7 @@ mod alternative_serializer_tests {
     #[test]
     fn test_fast_serialize_dict() -> SFVResult<()> {
         let output = RefDictSerializer::new()
-            .bare_item_member("member1", RefBareItem::Token("hello"))?
+            .bare_item_member("member1", token_ref("hello"))?
             .parameter("key1", true)?
             .parameter("key2", false)?
             .bare_item_member("member2", true)?

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use crate::{
-    BareItem, Decimal, Dictionary, Error, InnerList, Item, List, ListEntry, Parameters,
+    BareItem, Decimal, Dictionary, Error, InnerList, Integer, Item, List, ListEntry, Parameters,
     RefBareItem, SFVResult,
 };
 use std::fmt::Write as _;
@@ -155,7 +155,7 @@ impl Serializer {
             RefBareItem::String(value) => Self::serialize_string(value, output)?,
             RefBareItem::ByteSeq(value) => Self::serialize_byte_sequence(value, output),
             RefBareItem::Token(value) => Self::serialize_token(value, output)?,
-            RefBareItem::Integer(value) => Self::serialize_integer(value, output)?,
+            RefBareItem::Integer(value) => Self::serialize_integer(value, output),
             RefBareItem::Decimal(value) => Self::serialize_decimal(value, output)?,
         };
         Ok(())
@@ -213,15 +213,10 @@ impl Serializer {
         Ok(())
     }
 
-    pub(crate) fn serialize_integer(value: i64, output: &mut String) -> SFVResult<()> {
+    pub(crate) fn serialize_integer(value: Integer, output: &mut String) {
         //https://httpwg.org/specs/rfc8941.html#ser-integer
 
-        let (min_int, max_int) = (-999_999_999_999_999_i64, 999_999_999_999_999_i64);
-        if !(min_int <= value && value <= max_int) {
-            return Err(Error::new("serialize_integer: integer is out of range"));
-        }
         write!(output, "{}", value).unwrap();
-        Ok(())
     }
 
     pub(crate) fn serialize_decimal(value: Decimal, output: &mut String) -> SFVResult<()> {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,7 +1,7 @@
 use crate::utils;
 use crate::{
     BareItem, Decimal, Dictionary, Error, InnerList, Integer, Item, List, ListEntry, Parameters,
-    RefBareItem, SFVResult,
+    RefBareItem, SFVResult, TokenRef,
 };
 use std::fmt::Write as _;
 
@@ -154,7 +154,7 @@ impl Serializer {
             RefBareItem::Boolean(value) => Self::serialize_bool(value, output),
             RefBareItem::String(value) => Self::serialize_string(value, output)?,
             RefBareItem::ByteSeq(value) => Self::serialize_byte_sequence(value, output),
-            RefBareItem::Token(value) => Self::serialize_token(value, output)?,
+            RefBareItem::Token(value) => Self::serialize_token(value, output),
             RefBareItem::Integer(value) => Self::serialize_integer(value, output),
             RefBareItem::Decimal(value) => Self::serialize_decimal(value, output)?,
         };
@@ -267,32 +267,10 @@ impl Serializer {
         Ok(())
     }
 
-    pub(crate) fn serialize_token(value: &str, output: &mut String) -> SFVResult<()> {
+    pub(crate) fn serialize_token(value: &TokenRef, output: &mut String) {
         // https://httpwg.org/specs/rfc8941.html#ser-token
 
-        if !value.is_ascii() {
-            return Err(Error::new("serialize_token: non-ascii character"));
-        }
-
-        let mut bytes = value.bytes();
-
-        match bytes.next() {
-            None => return Err(Error::new("serialize_token: token is empty")),
-            Some(c) => {
-                if !utils::is_allowed_start_token_char(c) {
-                    return Err(Error::new(
-                        "serialize_token: first character is not ALPHA or '*'",
-                    ));
-                }
-            }
-        }
-
-        if bytes.any(|c| !utils::is_allowed_inner_token_char(c)) {
-            return Err(Error::new("serialize_token: disallowed character"));
-        }
-
-        output.push_str(value);
-        Ok(())
+        output.push_str(value.as_str());
     }
 
     pub(crate) fn serialize_byte_sequence(value: &[u8], output: &mut String) {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,7 +1,7 @@
 use crate::utils;
 use crate::{
-    AsRefBareItem, BareItem, Decimal, Dictionary, Error, InnerList, Item, List, ListEntry,
-    Parameters, RefBareItem, SFVResult,
+    BareItem, Decimal, Dictionary, Error, InnerList, Item, List, ListEntry, Parameters,
+    RefBareItem, SFVResult,
 };
 use std::fmt::Write as _;
 
@@ -144,13 +144,13 @@ impl Serializer {
         Self::serialize_parameters(inner_list_parameters, output)
     }
 
-    pub(crate) fn serialize_bare_item(
-        value: impl AsRefBareItem,
+    pub(crate) fn serialize_bare_item<'b>(
+        value: impl Into<RefBareItem<'b>>,
         output: &mut String,
     ) -> SFVResult<()> {
         // https://httpwg.org/specs/rfc8941.html#ser-bare-item
 
-        match value.as_ref_bare_item() {
+        match value.into() {
             RefBareItem::Boolean(value) => Self::serialize_bool(value, output),
             RefBareItem::String(value) => Self::serialize_string(value, output)?,
             RefBareItem::ByteSeq(value) => Self::serialize_byte_sequence(value, output),
@@ -173,15 +173,15 @@ impl Serializer {
         Ok(())
     }
 
-    pub(crate) fn serialize_parameter(
+    pub(crate) fn serialize_parameter<'b>(
         name: &str,
-        value: impl AsRefBareItem,
+        value: impl Into<RefBareItem<'b>>,
         output: &mut String,
     ) -> SFVResult<()> {
         output.push(';');
         Self::serialize_key(name, output)?;
 
-        let value = value.as_ref_bare_item();
+        let value = value.into();
         if value != RefBareItem::Boolean(true) {
             output.push('=');
             Self::serialize_bare_item(value, output)?;

--- a/src/string.rs
+++ b/src/string.rs
@@ -197,3 +197,17 @@ impl Borrow<str> for StringRef {
         self.as_str()
     }
 }
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for &'a StringRef {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        StringRef::from_str(<&str>::arbitrary(u)?).map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for String {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        <&StringRef>::arbitrary(u).map(ToOwned::to_owned)
+    }
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -95,6 +95,10 @@ impl ToOwned for StringRef {
     fn to_owned(&self) -> String {
         String(self.0.to_owned())
     }
+
+    fn clone_into(&self, target: &mut String) {
+        self.0.clone_into(&mut target.0);
+    }
 }
 
 impl Borrow<StringRef> for String {

--- a/src/string.rs
+++ b/src/string.rs
@@ -65,6 +65,7 @@ impl StringRef {
     }
 
     /// Creates a `&StringRef` from a `&str`.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(v: &str) -> Result<&Self, StringError> {
         validate(v.as_bytes())?;
         Ok(Self::cast(v))

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,199 @@
+use std::borrow::Borrow;
+use std::convert::TryFrom;
+use std::fmt;
+use std::string::String as StdString;
+
+/// An owned structured field value [string].
+///
+/// Strings may only contain printable ASCII characters (i.e. the range
+/// `0x20 ..= 0x7e`).
+///
+/// [string]: <https://httpwg.org/specs/rfc8941.html#string>
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct String(StdString);
+
+/// A borrowed structured field value [string].
+///
+/// Strings may only contain printable ASCII characters (i.e. the range
+/// `0x20 ..= 0x7e`).
+///
+/// This type is to [`String`] as [`str`] is to [`std::string::String`].
+///
+/// [string]: <https://httpwg.org/specs/rfc8941.html#string>
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, ref_cast::RefCastCustom)]
+#[repr(transparent)]
+pub struct StringRef(str);
+
+/// An error produced during conversion to a string.
+#[derive(Debug)]
+pub struct StringError {
+    byte_index: usize,
+}
+
+impl fmt::Display for StringError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "invalid character for string at byte index {}",
+            self.byte_index
+        )
+    }
+}
+
+impl std::error::Error for StringError {}
+
+const fn validate(v: &[u8]) -> Result<(), StringError> {
+    let mut index = 0;
+
+    while index < v.len() {
+        if v[index] < 0x20 || v[index] > 0x7e {
+            return Err(StringError { byte_index: index });
+        }
+        index += 1;
+    }
+
+    Ok(())
+}
+
+impl StringRef {
+    #[ref_cast::ref_cast_custom]
+    const fn cast(v: &str) -> &Self;
+
+    /// Creates an empty `&StringRef`.
+    pub const fn empty() -> &'static Self {
+        Self::cast("")
+    }
+
+    /// Creates a `&StringRef` from a `&str`.
+    pub fn from_str(v: &str) -> Result<&Self, StringError> {
+        validate(v.as_bytes())?;
+        Ok(Self::cast(v))
+    }
+
+    /// Creates a `&StringRef`, panicking if the value is invalid.
+    ///
+    /// This method is intended to be called from `const` contexts in which the
+    /// value is known to be valid. Use [`StringRef::from_str`] for non-panicking
+    /// conversions.
+    pub const fn constant(v: &str) -> &Self {
+        match validate(v.as_bytes()) {
+            Ok(_) => Self::cast(v),
+            Err(_) => panic!("invalid character for string"),
+        }
+    }
+
+    /// Returns the string as a `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl ToOwned for StringRef {
+    type Owned = String;
+
+    fn to_owned(&self) -> String {
+        String(self.0.to_owned())
+    }
+}
+
+impl Borrow<StringRef> for String {
+    fn borrow(&self) -> &StringRef {
+        self
+    }
+}
+
+impl std::ops::Deref for String {
+    type Target = StringRef;
+
+    fn deref(&self) -> &StringRef {
+        StringRef::cast(&self.0)
+    }
+}
+
+impl From<String> for StdString {
+    fn from(v: String) -> StdString {
+        v.0
+    }
+}
+
+impl TryFrom<StdString> for String {
+    type Error = StringError;
+
+    fn try_from(v: StdString) -> Result<String, StringError> {
+        validate(v.as_bytes())?;
+        Ok(String(v))
+    }
+}
+
+impl String {
+    /// Creates a `String` from a `std::string::String`.
+    ///
+    /// Returns the original value if the conversion failed.
+    pub fn from_string(v: StdString) -> Result<Self, (StringError, StdString)> {
+        match validate(v.as_bytes()) {
+            Ok(_) => Ok(Self(v)),
+            Err(err) => Err((err, v)),
+        }
+    }
+}
+
+/// Creates a `&StringRef`, panicking if the value is invalid.
+///
+/// This is a convenience free function for [`StringRef::constant`].
+///
+/// This method is intended to be called from `const` contexts in which the
+/// value is known to be valid. Use [`StringRef::from_str`] for non-panicking
+/// conversions.
+pub const fn string_ref(v: &str) -> &StringRef {
+    StringRef::constant(v)
+}
+
+impl fmt::Display for StringRef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+impl fmt::Display for String {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <StringRef as fmt::Display>::fmt(self, f)
+    }
+}
+
+macro_rules! impl_eq {
+    ($a: ty, $b: ty) => {
+        impl PartialEq<$a> for $b {
+            fn eq(&self, other: &$a) -> bool {
+                <StringRef as PartialEq>::eq(self, other)
+            }
+        }
+        impl PartialEq<$b> for $a {
+            fn eq(&self, other: &$b) -> bool {
+                <StringRef as PartialEq>::eq(self, other)
+            }
+        }
+    };
+}
+
+impl_eq!(String, StringRef);
+impl_eq!(String, &StringRef);
+
+impl<'a> TryFrom<&'a str> for &'a StringRef {
+    type Error = StringError;
+
+    fn try_from(v: &'a str) -> Result<&'a StringRef, StringError> {
+        StringRef::from_str(v)
+    }
+}
+
+impl Borrow<str> for String {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for StringRef {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -212,3 +212,9 @@ impl<'a> arbitrary::Arbitrary<'a> for String {
         <&StringRef>::arbitrary(u).map(ToOwned::to_owned)
     }
 }
+
+impl Default for &StringRef {
+    fn default() -> Self {
+        StringRef::empty()
+    }
+}

--- a/src/test_decimal.rs
+++ b/src/test_decimal.rs
@@ -1,0 +1,103 @@
+use crate::{Decimal, DecimalError, Integer};
+
+use std::convert::TryFrom;
+
+#[test]
+fn test_display() {
+    for (expected, input) in [
+        ("0.1", 100),
+        ("-0.1", -100),
+        ("0.01", 10),
+        ("-0.01", -10),
+        ("0.001", 1),
+        ("-0.001", -1),
+        ("0.12", 120),
+        ("-0.12", -120),
+        ("0.124", 124),
+        ("-0.124", -124),
+        ("0.125", 125),
+        ("-0.125", -125),
+        ("0.126", 126),
+        ("-0.126", -126),
+    ] {
+        let decimal = Decimal::from_integer_scaled_1000(Integer::constant(input));
+        assert_eq!(expected, decimal.to_string());
+    }
+
+    assert_eq!("0.0", Decimal::ZERO.to_string());
+    assert_eq!("-999999999999.999", Decimal::MIN.to_string());
+    assert_eq!("999999999999.999", Decimal::MAX.to_string());
+}
+
+#[test]
+fn test_into_f64() {
+    for (expected, input) in [
+        (0.0, 0),
+        (0.001, 1),
+        (0.01, 10),
+        (0.1, 100),
+        (1.0, 1000),
+        (10.0, 10000),
+        (0.123, 123),
+        (-0.001, -1),
+        (-0.01, -10),
+        (-0.1, -100),
+        (-1.0, -1000),
+        (-10.0, -10000),
+        (-0.123, -123),
+    ] {
+        assert_eq!(
+            expected,
+            f64::from(Decimal::from_integer_scaled_1000(input.into()))
+        );
+    }
+
+    assert_eq!(-999_999_999_999.999, f64::from(Decimal::MIN));
+
+    assert_eq!(999_999_999_999.999, f64::from(Decimal::MAX));
+}
+
+#[test]
+fn test_try_from_f64() {
+    for (expected, input) in [
+        (Err(DecimalError::NaN), f64::NAN),
+        (Err(DecimalError::OutOfRange), f64::INFINITY),
+        (Err(DecimalError::OutOfRange), f64::NEG_INFINITY),
+        (Err(DecimalError::OutOfRange), -1_000_000_000_000.0),
+        (Err(DecimalError::OutOfRange), 1_000_000_000_000.0),
+        (Ok(Decimal::MIN), -999_999_999_999.999),
+        (Ok(Decimal::MIN), -999_999_999_999.9991),
+        (Err(DecimalError::OutOfRange), -999_999_999_999.9995),
+        (Ok(Decimal::MAX), 999_999_999_999.999),
+        (Ok(Decimal::MAX), 999_999_999_999.9991),
+        (Err(DecimalError::OutOfRange), 999_999_999_999.9995),
+        (Ok(Decimal::ZERO), 0.0),
+        (Ok(Decimal::ZERO), -0.0),
+        (
+            Ok(Decimal::from_integer_scaled_1000(Integer::constant(123))),
+            0.1234,
+        ),
+        (
+            Ok(Decimal::from_integer_scaled_1000(Integer::constant(124))),
+            0.1235,
+        ),
+        (
+            Ok(Decimal::from_integer_scaled_1000(Integer::constant(124))),
+            0.1236,
+        ),
+        (
+            Ok(Decimal::from_integer_scaled_1000(Integer::constant(-123))),
+            -0.1234,
+        ),
+        (
+            Ok(Decimal::from_integer_scaled_1000(Integer::constant(-124))),
+            -0.1235,
+        ),
+        (
+            Ok(Decimal::from_integer_scaled_1000(Integer::constant(-124))),
+            -0.1236,
+        ),
+    ] {
+        assert_eq!(expected, Decimal::try_from(input));
+    }
+}

--- a/src/test_integer.rs
+++ b/src/test_integer.rs
@@ -1,0 +1,54 @@
+use crate::Integer;
+
+use std::convert::TryFrom;
+
+#[test]
+#[should_panic]
+fn test_constant_too_small() {
+    let _ = Integer::constant(-1_000_000_000_000_000);
+}
+
+#[test]
+#[should_panic]
+fn test_constant_too_large() {
+    let _ = Integer::constant(1_000_000_000_000_000);
+}
+
+#[test]
+fn test_conversions() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(Integer::MIN, Integer::constant(-999_999_999_999_999));
+    assert_eq!(Integer::MAX, Integer::constant(999_999_999_999_999));
+
+    assert!(Integer::try_from(-1_000_000_000_000_000_i64).is_err());
+    assert!(Integer::try_from(1_000_000_000_000_000_i64).is_err());
+
+    assert_eq!(i8::try_from(Integer::from(123_i8)), Ok(123));
+    assert_eq!(i16::try_from(Integer::from(123_i16)), Ok(123));
+    assert_eq!(i32::try_from(Integer::from(123_i32)), Ok(123));
+    assert_eq!(i64::from(Integer::try_from(123_i64)?), 123);
+    assert_eq!(i128::from(Integer::try_from(123_i128)?), 123);
+    assert_eq!(isize::try_from(Integer::try_from(123_isize)?), Ok(123));
+
+    assert_eq!(u8::try_from(Integer::from(123_u8)), Ok(123));
+    assert_eq!(u16::try_from(Integer::from(123_u16)), Ok(123));
+    assert_eq!(u32::try_from(Integer::from(123_u32)), Ok(123));
+    assert_eq!(u64::try_from(Integer::try_from(123_u64)?), Ok(123));
+    assert_eq!(u128::try_from(Integer::try_from(123_u128)?), Ok(123));
+    assert_eq!(usize::try_from(Integer::try_from(123_usize)?), Ok(123));
+
+    assert_eq!(i8::try_from(Integer::from(-123_i8)), Ok(-123));
+    assert_eq!(i16::try_from(Integer::from(-123_i16)), Ok(-123));
+    assert_eq!(i32::try_from(Integer::from(-123_i32)), Ok(-123));
+    assert_eq!(i64::from(Integer::try_from(-123_i64)?), -123);
+    assert_eq!(i128::from(Integer::try_from(-123_i128)?), -123);
+    assert_eq!(isize::try_from(Integer::try_from(-123_isize)?), Ok(-123));
+
+    assert!(u8::try_from(Integer::constant(-123)).is_err());
+    assert!(u16::try_from(Integer::constant(-123)).is_err());
+    assert!(u32::try_from(Integer::constant(-123)).is_err());
+    assert!(u64::try_from(Integer::constant(-123)).is_err());
+    assert!(u128::try_from(Integer::constant(-123)).is_err());
+    assert!(usize::try_from(Integer::constant(-123)).is_err());
+
+    Ok(())
+}

--- a/src/test_key.rs
+++ b/src/test_key.rs
@@ -1,0 +1,27 @@
+use crate::KeyRef;
+
+#[test]
+#[should_panic]
+fn test_constant_empty() {
+    let _ = KeyRef::constant("");
+}
+
+#[test]
+#[should_panic]
+fn test_constant_invalid_start_char() {
+    let _ = KeyRef::constant("_key");
+}
+
+#[test]
+#[should_panic]
+fn test_constant_invalid_inner_char() {
+    let _ = KeyRef::constant("aND");
+}
+
+#[test]
+fn test_conversions() {
+    assert!(KeyRef::from_str("").is_err());
+    assert!(KeyRef::from_str("aND").is_err());
+    assert!(KeyRef::from_str("_key").is_err());
+    assert!(KeyRef::from_str("7key").is_err());
+}

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -1,7 +1,8 @@
 use crate::{
-    integer, key_ref, string_ref, token_ref, BareItem, Decimal, Dictionary, Error, FromStr,
-    InnerList, Item, List, Num, Parameters, ParseMore, Parser,
+    integer, key_ref, string_ref, token_ref, BareItem, Decimal, Dictionary, Error, InnerList, Item,
+    List, Num, Parameters, ParseMore, Parser,
 };
+use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::iter::FromIterator;
 
@@ -14,7 +15,7 @@ fn parse() -> Result<(), Box<dyn StdError>> {
 
     let input = "12.35;a ";
     let params = Parameters::from_iter(vec![(key_ref("a").to_owned(), BareItem::Boolean(true))]);
-    let expected = Item::with_params(Decimal::from_str("12.35")?, params);
+    let expected = Item::with_params(Decimal::try_from(12.35)?, params);
 
     assert_eq!(expected, Parser::from_str(input).parse_item()?);
     Ok(())
@@ -230,7 +231,7 @@ fn parse_item_decimal_with_bool_param_and_space() -> Result<(), Box<dyn StdError
     let input = "12.35;a ";
     let param = Parameters::from_iter(vec![(key_ref("a").to_owned(), BareItem::Boolean(true))]);
     assert_eq!(
-        Item::with_params(Decimal::from_str("12.35")?, param),
+        Item::with_params(Decimal::try_from(12.35)?, param),
         Parser::from_str(input).parse_item()?
     );
     Ok(())
@@ -369,7 +370,7 @@ fn parse_bare_item() -> Result<(), Box<dyn StdError>> {
         Parser::from_str(":YmFzZV82NCBlbmNvZGluZyB0ZXN0:").parse_bare_item()?
     );
     assert_eq!(
-        BareItem::Decimal(Decimal::from_str("-3.55")?),
+        BareItem::Decimal(Decimal::try_from(-3.55)?),
         Parser::from_str("-3.55").parse_bare_item()?
     );
     Ok(())
@@ -621,37 +622,37 @@ fn parse_number_int() -> Result<(), Box<dyn StdError>> {
 fn parse_number_decimal() -> Result<(), Box<dyn StdError>> {
     let mut parser = Parser::from_str("00.42 test string");
     assert_eq!(
-        Num::Decimal(Decimal::from_str("0.42")?),
+        Num::Decimal(Decimal::try_from(0.42)?),
         parser.parse_number()?
     );
     assert_eq!(parser.remaining(), b" test string");
 
     assert_eq!(
-        Num::Decimal(Decimal::from_str("1.5")?),
+        Num::Decimal(Decimal::try_from(1.5)?),
         Parser::from_str("1.5.4.").parse_number()?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("1.8")?),
+        Num::Decimal(Decimal::try_from(1.8)?),
         Parser::from_str("1.8.").parse_number()?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("1.7")?),
+        Num::Decimal(Decimal::try_from(1.7)?),
         Parser::from_str("1.7.0").parse_number()?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("3.14")?),
+        Num::Decimal(Decimal::try_from(3.14)?),
         Parser::from_str("3.14").parse_number()?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("-3.14")?),
+        Num::Decimal(Decimal::try_from(-3.14)?),
         Parser::from_str("-3.14").parse_number()?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("123456789012.1")?),
+        Num::Decimal(Decimal::try_from(123456789012.1)?),
         Parser::from_str("123456789012.1").parse_number()?
     );
     assert_eq!(
-        Num::Decimal(Decimal::from_str("1234567890.112")?),
+        Num::Decimal(Decimal::try_from(1234567890.112)?),
         Parser::from_str("1234567890.112").parse_number()?
     );
 
@@ -761,7 +762,7 @@ fn parse_params_mixed_types() -> Result<(), Box<dyn StdError>> {
         (key_ref("key1").to_owned(), BareItem::Boolean(false)),
         (
             key_ref("key2").to_owned(),
-            Decimal::from_str("746.15")?.into(),
+            Decimal::try_from(746.15)?.into(),
         ),
     ]);
     assert_eq!(expected, Parser::from_str(input).parse_parameters()?);

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -14,7 +14,7 @@ fn parse() -> Result<(), Box<dyn StdError>> {
 
     let input = "12.35;a ";
     let params = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true))]);
-    let expected = Item::with_params(Decimal::from_str("12.35")?.into(), params);
+    let expected = Item::with_params(Decimal::from_str("12.35")?, params);
 
     assert_eq!(expected, Parser::from_str(input).parse_item()?);
     Ok(())
@@ -45,8 +45,8 @@ fn parse_errors() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn parse_list_of_numbers() -> Result<(), Box<dyn StdError>> {
     let input = "1,42";
-    let item1 = Item::new(1.into());
-    let item2 = Item::new(42.into());
+    let item1 = Item::new(1);
+    let item2 = Item::new(42);
     let expected_list: List = vec![item1.into(), item2.into()];
     assert_eq!(expected_list, Parser::from_str(input).parse_list()?);
     Ok(())
@@ -55,8 +55,8 @@ fn parse_list_of_numbers() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn parse_list_with_multiple_spaces() -> Result<(), Box<dyn StdError>> {
     let input = "1  ,  42";
-    let item1 = Item::new(1.into());
-    let item2 = Item::new(42.into());
+    let item1 = Item::new(1);
+    let item2 = Item::new(42);
     let expected_list: List = vec![item1.into(), item2.into()];
     assert_eq!(expected_list, Parser::from_str(input).parse_list()?);
     Ok(())
@@ -65,10 +65,10 @@ fn parse_list_with_multiple_spaces() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn parse_list_of_lists() -> Result<(), Box<dyn StdError>> {
     let input = "(1 2), (42 43)";
-    let item1 = Item::new(1.into());
-    let item2 = Item::new(2.into());
-    let item3 = Item::new(42.into());
-    let item4 = Item::new(43.into());
+    let item1 = Item::new(1);
+    let item2 = Item::new(2);
+    let item3 = Item::new(42);
+    let item4 = Item::new(43);
     let inner_list_1 = InnerList::new(vec![item1, item2]);
     let inner_list_2 = InnerList::new(vec![item3, item4]);
     let expected_list: List = vec![inner_list_1.into(), inner_list_2.into()];
@@ -96,8 +96,8 @@ fn parse_list_empty() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn parse_list_of_lists_with_param_and_spaces() -> Result<(), Box<dyn StdError>> {
     let input = "(  1  42  ); k=*";
-    let item1 = Item::new(1.into());
-    let item2 = Item::new(42.into());
+    let item1 = Item::new(1);
+    let item2 = Item::new(42);
     let inner_list_param =
         Parameters::from_iter(vec![("k".to_owned(), BareItem::Token("*".to_owned()))]);
     let inner_list = InnerList::with_params(vec![item1, item2], inner_list_param);
@@ -109,8 +109,8 @@ fn parse_list_of_lists_with_param_and_spaces() -> Result<(), Box<dyn StdError>> 
 #[test]
 fn parse_list_of_items_and_lists_with_param() -> Result<(), Box<dyn StdError>> {
     let input = r#"12, 14, (a  b); param="param_value_1", ()"#;
-    let item1 = Item::new(12.into());
-    let item2 = Item::new(14.into());
+    let item1 = Item::new(12);
+    let item2 = Item::new(14);
     let item3 = Item::new(BareItem::Token("a".to_owned()));
     let item4 = Item::new(BareItem::Token("b".to_owned()));
     let inner_list_param = Parameters::from_iter(vec![(
@@ -219,7 +219,7 @@ fn parse_inner_list_with_param_and_spaces() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn parse_item_int_with_space() -> Result<(), Box<dyn StdError>> {
     let input = "12 ";
-    assert_eq!(Item::new(12.into()), Parser::from_str(input).parse_item()?);
+    assert_eq!(Item::new(12), Parser::from_str(input).parse_item()?);
     Ok(())
 }
 
@@ -228,7 +228,7 @@ fn parse_item_decimal_with_bool_param_and_space() -> Result<(), Box<dyn StdError
     let input = "12.35;a ";
     let param = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true))]);
     assert_eq!(
-        Item::with_params(Decimal::from_str("12.35")?.into(), param),
+        Item::with_params(Decimal::from_str("12.35")?, param),
         Parser::from_str(input).parse_item()?
     );
     Ok(())
@@ -278,9 +278,9 @@ fn parse_dict_with_spaces_and_params() -> Result<(), Box<dyn StdError>> {
         ("r".to_owned(), BareItem::String("+w".to_owned())),
     ]);
 
-    let item1 = Item::with_params(123.into(), item1_params);
-    let item2 = Item::new(456.into());
-    let item3 = Item::with_params(789.into(), item3_params);
+    let item1 = Item::with_params(123, item1_params);
+    let item2 = Item::new(456);
+    let item3 = Item::with_params(789, item3_params);
 
     let expected_dict = Dictionary::from_iter(vec![
         ("abc".to_owned(), item1.into()),
@@ -306,9 +306,9 @@ fn parse_dict_with_token_param() -> Result<(), Box<dyn StdError>> {
     let input = "a=1, b;foo=*, c=3";
     let item2_params =
         Parameters::from_iter(vec![("foo".to_owned(), BareItem::Token("*".to_owned()))]);
-    let item1 = Item::new(1.into());
-    let item2 = Item::with_params(BareItem::Boolean(true), item2_params);
-    let item3 = Item::new(3.into());
+    let item1 = Item::new(1);
+    let item2 = Item::with_params(true, item2_params);
+    let item3 = Item::new(3);
     let expected_dict = Dictionary::from_iter(vec![
         ("a".to_owned(), item1.into()),
         ("b".to_owned(), item2.into()),
@@ -321,8 +321,8 @@ fn parse_dict_with_token_param() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn parse_dict_multiple_spaces() -> Result<(), Box<dyn StdError>> {
     // input1, input2, input3 must be parsed into the same structure
-    let item1 = Item::new(1.into());
-    let item2 = Item::new(2.into());
+    let item1 = Item::new(1);
+    let item2 = Item::new(2);
     let expected_dict = Dictionary::from_iter(vec![
         ("a".to_owned(), item1.into()),
         ("b".to_owned(), item2.into()),
@@ -781,9 +781,9 @@ fn parse_key_errors() -> Result<(), Box<dyn StdError>> {
 
 #[test]
 fn parse_more_list() -> Result<(), Box<dyn StdError>> {
-    let item1 = Item::new(1.into());
-    let item2 = Item::new(2.into());
-    let item3 = Item::new(42.into());
+    let item1 = Item::new(1);
+    let item2 = Item::new(2);
+    let item3 = Item::new(42);
     let inner_list_1 = InnerList::new(vec![item1, item2]);
     let expected_list: List = vec![inner_list_1.into(), item3.into()];
 
@@ -797,9 +797,9 @@ fn parse_more_list() -> Result<(), Box<dyn StdError>> {
 fn parse_more_dict() -> Result<(), Box<dyn StdError>> {
     let item2_params =
         Parameters::from_iter(vec![("foo".to_owned(), BareItem::Token("*".to_owned()))]);
-    let item1 = Item::new(1.into());
-    let item2 = Item::with_params(BareItem::Boolean(true), item2_params);
-    let item3 = Item::new(3.into());
+    let item1 = Item::new(1);
+    let item2 = Item::with_params(true, item2_params);
+    let item3 = Item::new(3);
     let expected_dict = Dictionary::from_iter(vec![
         ("a".to_owned(), item1.into()),
         ("b".to_owned(), item2.into()),

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -9,7 +9,7 @@ use std::iter::FromIterator;
 #[test]
 fn parse() -> Result<(), Box<dyn StdError>> {
     let input = r#""some_value""#;
-    let parsed_item = Item::new(string_ref("some_value").to_owned());
+    let parsed_item = Item::new(string_ref("some_value"));
     let expected = parsed_item;
     assert_eq!(expected, Parser::from_str(input).parse_item()?);
 
@@ -114,8 +114,8 @@ fn parse_list_of_items_and_lists_with_param() -> Result<(), Box<dyn StdError>> {
     let input = r#"12, 14, (a  b); param="param_value_1", ()"#;
     let item1 = Item::new(12);
     let item2 = Item::new(14);
-    let item3 = Item::new(token_ref("a").to_owned());
-    let item4 = Item::new(token_ref("b").to_owned());
+    let item3 = Item::new(token_ref("a"));
+    let item4 = Item::new(token_ref("b"));
     let inner_list_param = Parameters::from_iter(vec![(
         key_ref("param").to_owned(),
         BareItem::String(string_ref("param_value_1").to_owned()),
@@ -212,8 +212,8 @@ fn parse_inner_list_with_param_and_spaces() -> Result<(), Box<dyn StdError>> {
     let input = "(c b); a=1";
     let inner_list_param = Parameters::from_iter(vec![(key_ref("a").to_owned(), 1.into())]);
 
-    let item1 = Item::new(token_ref("c").to_owned());
-    let item2 = Item::new(token_ref("b").to_owned());
+    let item1 = Item::new(token_ref("c"));
+    let item2 = Item::new(token_ref("b"));
     let expected = InnerList::with_params(vec![item1, item2], inner_list_param);
     assert_eq!(expected, Parser::from_str(input).parse_inner_list()?);
     Ok(())
@@ -244,7 +244,7 @@ fn parse_item_number_with_param() -> Result<(), Box<dyn StdError>> {
         BareItem::Token(token_ref("*").to_owned()),
     )]);
     assert_eq!(
-        Item::with_params(string_ref("12.35").to_owned(), param),
+        Item::with_params(string_ref("12.35"), param),
         Parser::from_str(r#""12.35";a1=*"#).parse_item()?
     );
     Ok(())
@@ -366,7 +366,7 @@ fn parse_bare_item() -> Result<(), Box<dyn StdError>> {
         Parser::from_str("*token").parse_bare_item()?
     );
     assert_eq!(
-        BareItem::ByteSeq("base_64 encoding test".to_owned().into_bytes()),
+        BareItem::ByteSeq(b"base_64 encoding test".to_vec()),
         Parser::from_str(":YmFzZV82NCBlbmNvZGluZyB0ZXN0:").parse_bare_item()?
     );
     assert_eq!(
@@ -519,28 +519,22 @@ fn parse_token_errors() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn parse_byte_sequence() -> Result<(), Box<dyn StdError>> {
     let mut parser = Parser::from_str(":aGVsbG8:rest_of_str");
-    assert_eq!(
-        "hello".to_owned().into_bytes(),
-        parser.parse_byte_sequence()?
-    );
+    assert_eq!("hello".as_bytes(), parser.parse_byte_sequence()?);
     assert_eq!(parser.remaining(), b"rest_of_str");
 
     assert_eq!(
-        "hello".to_owned().into_bytes(),
+        "hello".as_bytes(),
         Parser::from_str(":aGVsbG8:").parse_byte_sequence()?
     );
     assert_eq!(
-        "test_encode".to_owned().into_bytes(),
+        "test_encode".as_bytes(),
         Parser::from_str(":dGVzdF9lbmNvZGU:").parse_byte_sequence()?
     );
     assert_eq!(
-        "new:year tree".to_owned().into_bytes(),
+        "new:year tree".as_bytes(),
         Parser::from_str(":bmV3OnllYXIgdHJlZQ==:").parse_byte_sequence()?
     );
-    assert_eq!(
-        "".to_owned().into_bytes(),
-        Parser::from_str("::").parse_byte_sequence()?
-    );
+    assert_eq!("".as_bytes(), Parser::from_str("::").parse_byte_sequence()?);
     Ok(())
 }
 

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -1,6 +1,6 @@
 use crate::{
-    integer, token_ref, BareItem, Decimal, Dictionary, Error, FromStr, InnerList, Item, List, Num,
-    Parameters, ParseMore, Parser,
+    integer, string_ref, token_ref, BareItem, Decimal, Dictionary, Error, FromStr, InnerList, Item,
+    List, Num, Parameters, ParseMore, Parser,
 };
 use std::error::Error as StdError;
 use std::iter::FromIterator;
@@ -8,7 +8,7 @@ use std::iter::FromIterator;
 #[test]
 fn parse() -> Result<(), Box<dyn StdError>> {
     let input = r#""some_value""#;
-    let parsed_item = Item::new(BareItem::String("some_value".to_owned()));
+    let parsed_item = Item::new(string_ref("some_value").to_owned());
     let expected = parsed_item;
     assert_eq!(expected, Parser::from_str(input).parse_item()?);
 
@@ -117,7 +117,7 @@ fn parse_list_of_items_and_lists_with_param() -> Result<(), Box<dyn StdError>> {
     let item4 = Item::new(token_ref("b").to_owned());
     let inner_list_param = Parameters::from_iter(vec![(
         "param".to_owned(),
-        BareItem::String("param_value_1".to_owned()),
+        BareItem::String(string_ref("param_value_1").to_owned()),
     )]);
     let inner_list = InnerList::with_params(vec![item3, item4], inner_list_param);
     let empty_inner_list = InnerList::new(vec![]);
@@ -243,7 +243,7 @@ fn parse_item_number_with_param() -> Result<(), Box<dyn StdError>> {
         BareItem::Token(token_ref("*").to_owned()),
     )]);
     assert_eq!(
-        Item::with_params(BareItem::String("12.35".to_owned()), param),
+        Item::with_params(string_ref("12.35").to_owned(), param),
         Parser::from_str(r#""12.35";a1=*"#).parse_item()?
     );
     Ok(())
@@ -280,7 +280,10 @@ fn parse_dict_with_spaces_and_params() -> Result<(), Box<dyn StdError>> {
         Parameters::from_iter(vec![("a".to_owned(), 1.into()), ("b".to_owned(), 2.into())]);
     let item3_params = Parameters::from_iter(vec![
         ("q".to_owned(), 9.into()),
-        ("r".to_owned(), BareItem::String("+w".to_owned())),
+        (
+            "r".to_owned(),
+            BareItem::String(string_ref("+w").to_owned()),
+        ),
     ]);
 
     let item1 = Item::with_params(123, item1_params);
@@ -352,7 +355,7 @@ fn parse_bare_item() -> Result<(), Box<dyn StdError>> {
         Parser::from_str("?0").parse_bare_item()?
     );
     assert_eq!(
-        BareItem::String("test string".to_owned()),
+        BareItem::String(string_ref("test string").to_owned()),
         Parser::from_str(r#""test string""#).parse_bare_item()?
     );
     assert_eq!(
@@ -414,20 +417,20 @@ fn parse_bool_errors() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn parse_string() -> Result<(), Box<dyn StdError>> {
     let mut parser = Parser::from_str(r#""some string" ;not string"#);
-    assert_eq!("some string".to_owned(), parser.parse_string()?);
+    assert_eq!(string_ref("some string"), parser.parse_string()?);
     assert_eq!(parser.remaining(), " ;not string".as_bytes());
 
     assert_eq!(
-        "test".to_owned(),
+        string_ref("test"),
         Parser::from_str(r#""test""#).parse_string()?
     );
     assert_eq!(
-        r#"te\st"#.to_owned(),
+        string_ref(r#"te\st"#),
         Parser::from_str(r#""te\\st""#).parse_string()?
     );
-    assert_eq!("".to_owned(), Parser::from_str(r#""""#).parse_string()?);
+    assert_eq!(string_ref(""), Parser::from_str(r#""""#).parse_string()?);
     assert_eq!(
-        "some string".to_owned(),
+        string_ref("some string"),
         Parser::from_str(r#""some string""#).parse_string()?
     );
     Ok(())
@@ -732,7 +735,7 @@ fn parse_params_string() -> Result<(), Box<dyn StdError>> {
     let input = r#";b="param_val""#;
     let expected = Parameters::from_iter(vec![(
         "b".to_owned(),
-        BareItem::String("param_val".to_owned()),
+        BareItem::String(string_ref("param_val").to_owned()),
     )]);
     assert_eq!(expected, Parser::from_str(input).parse_parameters()?);
     Ok(())

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BareItem, Decimal, Dictionary, Error, FromStr, InnerList, Item, List, Num, Parameters,
+    integer, BareItem, Decimal, Dictionary, Error, FromStr, InnerList, Item, List, Num, Parameters,
     ParseMore, Parser,
 };
 use std::error::Error as StdError;
@@ -554,30 +554,51 @@ fn parse_byte_sequence_errors() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn parse_number_int() -> Result<(), Box<dyn StdError>> {
     let mut parser = Parser::from_str("-733333333332d.14");
-    assert_eq!(Num::Integer(-733333333332), parser.parse_number()?);
+    assert_eq!(Num::Integer(integer(-733333333332)), parser.parse_number()?);
     assert_eq!(parser.remaining(), b"d.14");
 
-    assert_eq!(Num::Integer(42), Parser::from_str("42").parse_number()?);
-    assert_eq!(Num::Integer(-42), Parser::from_str("-42").parse_number()?);
-    assert_eq!(Num::Integer(-42), Parser::from_str("-042").parse_number()?);
-    assert_eq!(Num::Integer(0), Parser::from_str("0").parse_number()?);
-    assert_eq!(Num::Integer(0), Parser::from_str("00").parse_number()?);
     assert_eq!(
-        Num::Integer(123456789012345),
+        Num::Integer(integer(42)),
+        Parser::from_str("42").parse_number()?
+    );
+    assert_eq!(
+        Num::Integer(integer(-42)),
+        Parser::from_str("-42").parse_number()?
+    );
+    assert_eq!(
+        Num::Integer(integer(-42)),
+        Parser::from_str("-042").parse_number()?
+    );
+    assert_eq!(
+        Num::Integer(integer(0)),
+        Parser::from_str("0").parse_number()?
+    );
+    assert_eq!(
+        Num::Integer(integer(0)),
+        Parser::from_str("00").parse_number()?
+    );
+    assert_eq!(
+        Num::Integer(integer(123456789012345)),
         Parser::from_str("123456789012345").parse_number()?
     );
     assert_eq!(
-        Num::Integer(-123456789012345),
+        Num::Integer(integer(-123456789012345)),
         Parser::from_str("-123456789012345").parse_number()?
     );
-    assert_eq!(Num::Integer(2), Parser::from_str("2,3").parse_number()?);
-    assert_eq!(Num::Integer(4), Parser::from_str("4-2").parse_number()?);
     assert_eq!(
-        Num::Integer(-999999999999999),
+        Num::Integer(integer(2)),
+        Parser::from_str("2,3").parse_number()?
+    );
+    assert_eq!(
+        Num::Integer(integer(4)),
+        Parser::from_str("4-2").parse_number()?
+    );
+    assert_eq!(
+        Num::Integer(integer(-999999999999999)),
         Parser::from_str("-999999999999999").parse_number()?
     );
     assert_eq!(
-        Num::Integer(999999999999999),
+        Num::Integer(integer(999999999999999)),
         Parser::from_str("999999999999999").parse_number()?
     );
 

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -1,6 +1,6 @@
 use crate::{
     integer, key_ref, string_ref, token_ref, BareItem, Decimal, Dictionary, Error, InnerList, Item,
-    List, Num, Parameters, ParseMore, Parser,
+    List, Num, Parameters, ParseMore, Parser, RefBareItem,
 };
 use std::convert::TryFrom;
 use std::error::Error as StdError;
@@ -354,23 +354,23 @@ fn parse_dict_multiple_spaces() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn parse_bare_item() -> Result<(), Box<dyn StdError>> {
     assert_eq!(
-        BareItem::Boolean(false),
+        RefBareItem::Boolean(false),
         Parser::from_str("?0").parse_bare_item()?
     );
     assert_eq!(
-        BareItem::String(string_ref("test string").to_owned()),
+        RefBareItem::String(string_ref("test string")),
         Parser::from_str(r#""test string""#).parse_bare_item()?
     );
     assert_eq!(
-        BareItem::Token(token_ref("*token").to_owned()),
+        RefBareItem::Token(token_ref("*token")),
         Parser::from_str("*token").parse_bare_item()?
     );
     assert_eq!(
-        BareItem::ByteSeq(b"base_64 encoding test".to_vec()),
+        RefBareItem::ByteSeq(b"base_64 encoding test"),
         Parser::from_str(":YmFzZV82NCBlbmNvZGluZyB0ZXN0:").parse_bare_item()?
     );
     assert_eq!(
-        BareItem::Decimal(Decimal::try_from(-3.55)?),
+        RefBareItem::Decimal(Decimal::try_from(-3.55)?),
         Parser::from_str("-3.55").parse_bare_item()?
     );
     Ok(())

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -45,15 +45,15 @@ fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn StdErr
         key_ref("in1_p").to_owned(),
         BareItem::Boolean(false),
     )]);
-    let inner_list_item1 = Item::with_params(string_ref("str1").to_owned(), inner_list_item1_param);
+    let inner_list_item1 = Item::with_params(string_ref("str1"), inner_list_item1_param);
     let inner_list_item2_param = Parameters::from_iter(vec![(
         key_ref("in2_p").to_owned(),
         BareItem::String(string_ref(r#"valu\e"#).to_owned()),
     )]);
-    let inner_list_item2 = Item::with_params(token_ref("str2").to_owned(), inner_list_item2_param);
+    let inner_list_item2 = Item::with_params(token_ref("str2"), inner_list_item2_param);
     let inner_list_param = Parameters::from_iter(vec![(
         key_ref("inner_list_param").to_owned(),
-        BareItem::ByteSeq("weather".as_bytes().to_vec()),
+        BareItem::ByteSeq(b"weather".to_vec()),
     )]);
     let inner_list =
         InnerList::with_params(vec![inner_list_item1, inner_list_item2], inner_list_param);
@@ -103,7 +103,7 @@ fn serialize_item_with_token_param() {
         key_ref("a1").to_owned(),
         BareItem::Token(token_ref("*tok").to_owned()),
     )]);
-    let item = Item::with_params(string_ref("12.35").to_owned(), param);
+    let item = Item::with_params(string_ref("12.35"), param);
     Serializer::serialize_item(&item, &mut buf);
     assert_eq!(r#""12.35";a1=*tok"#, &buf);
 }
@@ -341,8 +341,8 @@ fn serialize_list_of_items_and_inner_list() -> Result<(), Box<dyn StdError>> {
 
     let item1 = Item::new(12);
     let item2 = Item::new(14);
-    let item3 = Item::new(token_ref("a").to_owned());
-    let item4 = Item::new(token_ref("b").to_owned());
+    let item3 = Item::new(token_ref("a"));
+    let item4 = Item::new(token_ref("b"));
     let inner_list_param = Parameters::from_iter(vec![(
         key_ref("param").to_owned(),
         BareItem::String(string_ref("param_value_1").to_owned()),
@@ -381,7 +381,7 @@ fn serialize_list_with_bool_item_and_bool_params() -> Result<(), Box<dyn StdErro
         (key_ref("b").to_owned(), BareItem::Boolean(false)),
     ]);
     let item1 = Item::with_params(false, item1_params);
-    let item2 = Item::new(token_ref("cde_456").to_owned());
+    let item2 = Item::new(token_ref("cde_456"));
 
     let input: List = vec![item1.into(), item2.into()];
     Serializer::serialize_list(&input, &mut buf)?;

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -2,8 +2,8 @@ use crate::serializer::Serializer;
 use crate::FromStr;
 use crate::SerializeValue;
 use crate::{
-    integer, string_ref, token_ref, BareItem, Decimal, Dictionary, Error, InnerList, Item, List,
-    Parameters,
+    integer, key_ref, string_ref, token_ref, BareItem, Decimal, Dictionary, Error, InnerList, Item,
+    List, Parameters,
 };
 use std::error::Error as StdError;
 use std::iter::FromIterator;
@@ -35,19 +35,24 @@ fn serialize_value_empty_list() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn StdError>> {
     let item1 = Item::new(Decimal::from_str("42.4568")?);
-    let item2_param = Parameters::from_iter(vec![("itm2_p".to_owned(), BareItem::Boolean(true))]);
+    let item2_param = Parameters::from_iter(vec![(
+        key_ref("itm2_p").to_owned(),
+        BareItem::Boolean(true),
+    )]);
     let item2 = Item::with_params(17, item2_param);
 
-    let inner_list_item1_param =
-        Parameters::from_iter(vec![("in1_p".to_owned(), BareItem::Boolean(false))]);
+    let inner_list_item1_param = Parameters::from_iter(vec![(
+        key_ref("in1_p").to_owned(),
+        BareItem::Boolean(false),
+    )]);
     let inner_list_item1 = Item::with_params(string_ref("str1").to_owned(), inner_list_item1_param);
     let inner_list_item2_param = Parameters::from_iter(vec![(
-        "in2_p".to_owned(),
+        key_ref("in2_p").to_owned(),
         BareItem::String(string_ref(r#"valu\e"#).to_owned()),
     )]);
     let inner_list_item2 = Item::with_params(token_ref("str2").to_owned(), inner_list_item2_param);
     let inner_list_param = Parameters::from_iter(vec![(
-        "inner_list_param".to_owned(),
+        key_ref("inner_list_param").to_owned(),
         BareItem::ByteSeq("weather".as_bytes().to_vec()),
     )]);
     let inner_list =
@@ -68,15 +73,6 @@ fn serialize_value_errors() -> Result<(), Box<dyn StdError>> {
         )),
         disallowed_item.serialize_value()
     );
-
-    let param_with_disallowed_key = Parameters::from_iter(vec![("_key".to_owned(), 13.into())]);
-    let disallowed_item = Item::with_params(12, param_with_disallowed_key);
-    assert_eq!(
-        Err(Error::new(
-            "serialize_key: first character is not lcalpha or '*'"
-        )),
-        disallowed_item.serialize_value()
-    );
     Ok(())
 }
 
@@ -85,7 +81,7 @@ fn serialize_item_byteseq_with_param() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
 
     let item_param = (
-        "a".to_owned(),
+        key_ref("a").to_owned(),
         BareItem::Token(token_ref("*ab_1").to_owned()),
     );
     let item_param = Parameters::from_iter(vec![item_param]);
@@ -107,7 +103,7 @@ fn serialize_item_without_params() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn serialize_item_with_bool_true_param() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
-    let param = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true))]);
+    let param = Parameters::from_iter(vec![(key_ref("a").to_owned(), BareItem::Boolean(true))]);
     let item = Item::with_params(Decimal::from_str("12.35")?, param);
     Serializer::serialize_item(&item, &mut buf)?;
     assert_eq!("12.35;a", &buf);
@@ -118,7 +114,7 @@ fn serialize_item_with_bool_true_param() -> Result<(), Box<dyn StdError>> {
 fn serialize_item_with_token_param() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
     let param = Parameters::from_iter(vec![(
-        "a1".to_owned(),
+        key_ref("a1").to_owned(),
         BareItem::Token(token_ref("*tok").to_owned()),
     )]);
     let item = Item::with_params(string_ref("12.35").to_owned(), param);
@@ -298,8 +294,8 @@ fn serialize_params_bool() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
 
     let input = Parameters::from_iter(vec![
-        ("*b".to_owned(), BareItem::Boolean(true)),
-        ("a.a".to_owned(), BareItem::Boolean(true)),
+        (key_ref("*b").to_owned(), BareItem::Boolean(true)),
+        (key_ref("a.a").to_owned(), BareItem::Boolean(true)),
     ]);
 
     Serializer::serialize_parameters(&input, &mut buf)?;
@@ -312,7 +308,7 @@ fn serialize_params_string() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
 
     let input = Parameters::from_iter(vec![(
-        "b".to_owned(),
+        key_ref("b").to_owned(),
         BareItem::String(string_ref("param_val").to_owned()),
     )]);
     Serializer::serialize_parameters(&input, &mut buf)?;
@@ -325,8 +321,11 @@ fn serialize_params_numbers() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
 
     let input = Parameters::from_iter(vec![
-        ("key1".to_owned(), Decimal::from_str("746.15")?.into()),
-        ("key2".to_owned(), 11111.into()),
+        (
+            key_ref("key1").to_owned(),
+            Decimal::from_str("746.15")?.into(),
+        ),
+        (key_ref("key2").to_owned(), 11111.into()),
     ]);
     Serializer::serialize_parameters(&input, &mut buf)?;
     assert_eq!(";key1=746.15;key2=11111", &buf);
@@ -338,8 +337,11 @@ fn serialize_params_mixed_types() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
 
     let input = Parameters::from_iter(vec![
-        ("key1".to_owned(), BareItem::Boolean(false)),
-        ("key2".to_owned(), Decimal::from_str("1354.091878")?.into()),
+        (key_ref("key1").to_owned(), BareItem::Boolean(false)),
+        (
+            key_ref("key2").to_owned(),
+            Decimal::from_str("1354.091878")?.into(),
+        ),
     ]);
     Serializer::serialize_parameters(&input, &mut buf)?;
     assert_eq!(";key1=?0;key2=1354.092", &buf);
@@ -347,51 +349,22 @@ fn serialize_params_mixed_types() -> Result<(), Box<dyn StdError>> {
 }
 
 #[test]
-fn serialize_key() -> Result<(), Box<dyn StdError>> {
+fn serialize_key() {
     let mut buf = String::new();
-    Serializer::serialize_key("*a_fg", &mut buf)?;
+    Serializer::serialize_key(key_ref("*a_fg"), &mut buf);
     assert_eq!("*a_fg", &buf);
 
     buf.clear();
-    Serializer::serialize_key("*a_fg*", &mut buf)?;
+    Serializer::serialize_key(key_ref("*a_fg*"), &mut buf);
     assert_eq!("*a_fg*", &buf);
 
     buf.clear();
-    Serializer::serialize_key("key1", &mut buf)?;
+    Serializer::serialize_key(key_ref("key1"), &mut buf);
     assert_eq!("key1", &buf);
 
     buf.clear();
-    Serializer::serialize_key("ke-y.1", &mut buf)?;
+    Serializer::serialize_key(key_ref("ke-y.1"), &mut buf);
     assert_eq!("ke-y.1", &buf);
-
-    Ok(())
-}
-
-#[test]
-fn serialize_key_errors() -> Result<(), Box<dyn StdError>> {
-    let mut buf = String::new();
-
-    assert_eq!(
-        Err(Error::new("serialize_key: key is empty")),
-        Serializer::serialize_key("", &mut buf)
-    );
-    assert_eq!(
-        Err(Error::new("serialize_key: disallowed character")),
-        Serializer::serialize_key("aND", &mut buf)
-    );
-    assert_eq!(
-        Err(Error::new(
-            "serialize_key: first character is not lcalpha or '*'"
-        )),
-        Serializer::serialize_key("_key", &mut buf)
-    );
-    assert_eq!(
-        Err(Error::new(
-            "serialize_key: first character is not lcalpha or '*'"
-        )),
-        Serializer::serialize_key("7key", &mut buf)
-    );
-    Ok(())
 }
 
 #[test]
@@ -403,7 +376,7 @@ fn serialize_list_of_items_and_inner_list() -> Result<(), Box<dyn StdError>> {
     let item3 = Item::new(token_ref("a").to_owned());
     let item4 = Item::new(token_ref("b").to_owned());
     let inner_list_param = Parameters::from_iter(vec![(
-        "param".to_owned(),
+        key_ref("param").to_owned(),
         BareItem::String(string_ref("param_value_1").to_owned()),
     )]);
     let inner_list = InnerList::with_params(vec![item3, item4], inner_list_param);
@@ -436,8 +409,8 @@ fn serialize_list_with_bool_item_and_bool_params() -> Result<(), Box<dyn StdErro
     let mut buf = String::new();
 
     let item1_params = Parameters::from_iter(vec![
-        ("a".to_owned(), BareItem::Boolean(true)),
-        ("b".to_owned(), BareItem::Boolean(false)),
+        (key_ref("a").to_owned(), BareItem::Boolean(true)),
+        (key_ref("b").to_owned(), BareItem::Boolean(false)),
     ]);
     let item1 = Item::with_params(false, item1_params);
     let item2 = Item::new(token_ref("cde_456").to_owned());
@@ -453,14 +426,14 @@ fn serialize_dictionary_with_params() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
 
     let item1_params = Parameters::from_iter(vec![
-        ("a".to_owned(), 1.into()),
-        ("b".to_owned(), BareItem::Boolean(true)),
+        (key_ref("a").to_owned(), 1.into()),
+        (key_ref("b").to_owned(), BareItem::Boolean(true)),
     ]);
     let item2_params = Parameters::new();
     let item3_params = Parameters::from_iter(vec![
-        ("q".to_owned(), BareItem::Boolean(false)),
+        (key_ref("q").to_owned(), BareItem::Boolean(false)),
         (
-            "r".to_owned(),
+            key_ref("r").to_owned(),
             BareItem::String(string_ref("+w").to_owned()),
         ),
     ]);
@@ -470,9 +443,9 @@ fn serialize_dictionary_with_params() -> Result<(), Box<dyn StdError>> {
     let item3 = Item::with_params(789, item3_params);
 
     let input = Dictionary::from_iter(vec![
-        ("abc".to_owned(), item1.into()),
-        ("def".to_owned(), item2.into()),
-        ("ghi".to_owned(), item3.into()),
+        (key_ref("abc").to_owned(), item1.into()),
+        (key_ref("def").to_owned(), item2.into()),
+        (key_ref("ghi").to_owned(), item3.into()),
     ]);
 
     Serializer::serialize_dict(&input, &mut buf)?;
@@ -485,7 +458,7 @@ fn serialize_dict_empty_member_value() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
 
     let inner_list = InnerList::new(vec![]);
-    let input = Dictionary::from_iter(vec![("a".to_owned(), inner_list.into())]);
+    let input = Dictionary::from_iter(vec![(key_ref("a").to_owned(), inner_list.into())]);
     Serializer::serialize_dict(&input, &mut buf)?;
     assert_eq!("a=()", &buf);
     Ok(())

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -31,9 +31,9 @@ fn serialize_value_empty_list() -> Result<(), Box<dyn StdError>> {
 
 #[test]
 fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn StdError>> {
-    let item1 = Item::new(Decimal::from_str("42.4568")?.into());
+    let item1 = Item::new(Decimal::from_str("42.4568")?);
     let item2_param = Parameters::from_iter(vec![("itm2_p".to_owned(), BareItem::Boolean(true))]);
-    let item2 = Item::with_params(17.into(), item2_param);
+    let item2 = Item::with_params(17, item2_param);
 
     let inner_list_item1_param =
         Parameters::from_iter(vec![("in1_p".to_owned(), BareItem::Boolean(false))]);
@@ -66,7 +66,7 @@ fn serialize_value_errors() -> Result<(), Box<dyn StdError>> {
         disallowed_item.serialize_value()
     );
 
-    let disallowed_item = Item::new(Decimal::from_str("12345678912345.123")?.into());
+    let disallowed_item = Item::new(Decimal::from_str("12345678912345.123")?);
     assert_eq!(
         Err(Error::new(
             "serialize_decimal: integer component > 12 digits"
@@ -75,7 +75,7 @@ fn serialize_value_errors() -> Result<(), Box<dyn StdError>> {
     );
 
     let param_with_disallowed_key = Parameters::from_iter(vec![("_key".to_owned(), 13.into())]);
-    let disallowed_item = Item::with_params(12.into(), param_with_disallowed_key);
+    let disallowed_item = Item::with_params(12, param_with_disallowed_key);
     assert_eq!(
         Err(Error::new(
             "serialize_key: first character is not lcalpha or '*'"
@@ -91,7 +91,7 @@ fn serialize_item_byteseq_with_param() -> Result<(), Box<dyn StdError>> {
 
     let item_param = ("a".to_owned(), BareItem::Token("*ab_1".into()));
     let item_param = Parameters::from_iter(vec![item_param]);
-    let item = Item::with_params(BareItem::ByteSeq("parser".as_bytes().to_vec()), item_param);
+    let item = Item::with_params(b"parser".to_vec(), item_param);
     Serializer::serialize_item(&item, &mut buf)?;
     assert_eq!(":cGFyc2Vy:;a=*ab_1", &buf);
     Ok(())
@@ -100,7 +100,7 @@ fn serialize_item_byteseq_with_param() -> Result<(), Box<dyn StdError>> {
 #[test]
 fn serialize_item_without_params() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
-    let item = Item::new(1.into());
+    let item = Item::new(1);
     Serializer::serialize_item(&item, &mut buf)?;
     assert_eq!("1", &buf);
     Ok(())
@@ -110,7 +110,7 @@ fn serialize_item_without_params() -> Result<(), Box<dyn StdError>> {
 fn serialize_item_with_bool_true_param() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
     let param = Parameters::from_iter(vec![("a".to_owned(), BareItem::Boolean(true))]);
-    let item = Item::with_params(Decimal::from_str("12.35")?.into(), param);
+    let item = Item::with_params(Decimal::from_str("12.35")?, param);
     Serializer::serialize_item(&item, &mut buf)?;
     assert_eq!("12.35;a", &buf);
     Ok(())
@@ -465,8 +465,8 @@ fn serialize_key_errors() -> Result<(), Box<dyn StdError>> {
 fn serialize_list_of_items_and_inner_list() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
 
-    let item1 = Item::new(12.into());
-    let item2 = Item::new(14.into());
+    let item1 = Item::new(12);
+    let item2 = Item::new(14);
     let item3 = Item::new(BareItem::Token("a".to_owned()));
     let item4 = Item::new(BareItem::Token("b".to_owned()));
     let inner_list_param = Parameters::from_iter(vec![(
@@ -485,10 +485,10 @@ fn serialize_list_of_items_and_inner_list() -> Result<(), Box<dyn StdError>> {
 fn serialize_list_of_lists() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
 
-    let item1 = Item::new(1.into());
-    let item2 = Item::new(2.into());
-    let item3 = Item::new(42.into());
-    let item4 = Item::new(43.into());
+    let item1 = Item::new(1);
+    let item2 = Item::new(2);
+    let item3 = Item::new(42);
+    let item4 = Item::new(43);
     let inner_list_1 = InnerList::new(vec![item1, item2]);
     let inner_list_2 = InnerList::new(vec![item3, item4]);
     let input: List = vec![inner_list_1.into(), inner_list_2.into()];
@@ -506,7 +506,7 @@ fn serialize_list_with_bool_item_and_bool_params() -> Result<(), Box<dyn StdErro
         ("a".to_owned(), BareItem::Boolean(true)),
         ("b".to_owned(), BareItem::Boolean(false)),
     ]);
-    let item1 = Item::with_params(BareItem::Boolean(false), item1_params);
+    let item1 = Item::with_params(false, item1_params);
     let item2 = Item::new(BareItem::Token("cde_456".to_owned()));
 
     let input: List = vec![item1.into(), item2.into()];
@@ -529,9 +529,9 @@ fn serialize_dictionary_with_params() -> Result<(), Box<dyn StdError>> {
         ("r".to_owned(), BareItem::String("+w".to_owned())),
     ]);
 
-    let item1 = Item::with_params(123.into(), item1_params);
-    let item2 = Item::with_params(456.into(), item2_params);
-    let item3 = Item::with_params(789.into(), item3_params);
+    let item1 = Item::with_params(123, item1_params);
+    let item2 = Item::with_params(456, item2_params);
+    let item3 = Item::with_params(789, item3_params);
 
     let input = Dictionary::from_iter(vec![
         ("abc".to_owned(), item1.into()),

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -1,7 +1,7 @@
 use crate::serializer::Serializer;
 use crate::FromStr;
 use crate::SerializeValue;
-use crate::{BareItem, Decimal, Dictionary, Error, InnerList, Item, List, Parameters};
+use crate::{integer, BareItem, Decimal, Dictionary, Error, InnerList, Item, List, Parameters};
 use std::error::Error as StdError;
 use std::iter::FromIterator;
 
@@ -127,39 +127,22 @@ fn serialize_item_with_token_param() -> Result<(), Box<dyn StdError>> {
 }
 
 #[test]
-fn serialize_integer() -> Result<(), Box<dyn StdError>> {
+fn serialize_integer() {
     let mut buf = String::new();
-    Serializer::serialize_integer(-12, &mut buf)?;
+    Serializer::serialize_integer(integer(-12), &mut buf);
     assert_eq!("-12", &buf);
 
     buf.clear();
-    Serializer::serialize_integer(0, &mut buf)?;
+    Serializer::serialize_integer(integer(0), &mut buf);
     assert_eq!("0", &buf);
 
     buf.clear();
-    Serializer::serialize_integer(999_999_999_999_999, &mut buf)?;
+    Serializer::serialize_integer(integer(999_999_999_999_999), &mut buf);
     assert_eq!("999999999999999", &buf);
 
     buf.clear();
-    Serializer::serialize_integer(-999_999_999_999_999, &mut buf)?;
+    Serializer::serialize_integer(integer(-999_999_999_999_999), &mut buf);
     assert_eq!("-999999999999999", &buf);
-    Ok(())
-}
-
-#[test]
-fn serialize_integer_errors() -> Result<(), Box<dyn StdError>> {
-    let mut buf = String::new();
-    assert_eq!(
-        Err(Error::new("serialize_integer: integer is out of range")),
-        Serializer::serialize_integer(1_000_000_000_000_000, &mut buf)
-    );
-
-    buf.clear();
-    assert_eq!(
-        Err(Error::new("serialize_integer: integer is out of range")),
-        Serializer::serialize_integer(-1_000_000_000_000_000, &mut buf)
-    );
-    Ok(())
 }
 
 #[test]

--- a/src/test_string.rs
+++ b/src/test_string.rs
@@ -1,0 +1,16 @@
+use crate::StringRef;
+
+#[test]
+#[should_panic]
+fn test_constant_invalid_char() {
+    let _ = StringRef::constant("text \x00");
+}
+
+#[test]
+fn test_conversions() {
+    assert!(StringRef::from_str("text \x00").is_err());
+    assert!(StringRef::from_str("text \x1f").is_err());
+    assert!(StringRef::from_str("text \x7f").is_err());
+    assert!(StringRef::from_str("рядок").is_err());
+    assert!(StringRef::from_str("non-ascii text 🐹").is_err());
+}

--- a/src/test_token.rs
+++ b/src/test_token.rs
@@ -1,0 +1,27 @@
+use crate::TokenRef;
+
+#[test]
+#[should_panic]
+fn test_constant_empty() {
+    let _ = TokenRef::constant("");
+}
+
+#[test]
+#[should_panic]
+fn test_constant_invalid_start_char() {
+    let _ = TokenRef::constant("#some");
+}
+
+#[test]
+#[should_panic]
+fn test_constant_invalid_inner_char() {
+    let _ = TokenRef::constant("s ");
+}
+
+#[test]
+fn test_conversions() {
+    assert!(TokenRef::from_str("").is_err());
+    assert!(TokenRef::from_str("#some").is_err());
+    assert!(TokenRef::from_str("s ").is_err());
+    assert!(TokenRef::from_str("abc:de\t").is_err());
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -89,6 +89,13 @@ impl TokenRef {
         Ok(Self::cast(v))
     }
 
+    // Like `from_str`, but assumes that the contents of the string have already
+    // been validated as a token.
+    pub(crate) fn from_validated_str(v: &str) -> &Self {
+        debug_assert!(validate(v.as_bytes()).is_ok());
+        Self::cast(v)
+    }
+
     /// Creates a `&TokenRef`, panicking if the value is invalid.
     ///
     /// This method is intended to be called from `const` contexts in which the

--- a/src/token.rs
+++ b/src/token.rs
@@ -126,6 +126,10 @@ impl ToOwned for TokenRef {
     fn to_owned(&self) -> Token {
         Token(self.0.to_owned())
     }
+
+    fn clone_into(&self, target: &mut Token) {
+        self.0.clone_into(&mut target.0);
+    }
 }
 
 impl Borrow<TokenRef> for Token {

--- a/src/token.rs
+++ b/src/token.rs
@@ -221,3 +221,17 @@ impl Borrow<str> for TokenRef {
         self.as_str()
     }
 }
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for &'a TokenRef {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        TokenRef::from_str(<&str>::arbitrary(u)?).map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Token {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        <&TokenRef>::arbitrary(u).map(ToOwned::to_owned)
+    }
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -83,6 +83,7 @@ impl TokenRef {
     const fn cast(v: &str) -> &Self;
 
     /// Creates a `&TokenRef` from a `&str`.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(v: &str) -> Result<&Self, TokenError> {
         validate(v.as_bytes())?;
         Ok(Self::cast(v))

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,223 @@
+use crate::utils;
+
+use std::borrow::Borrow;
+use std::convert::TryFrom;
+use std::fmt;
+
+/// An owned structured field value [token].
+///
+/// Tokens must match the following regular expression:
+///
+/// ```re
+/// ^[A-Za-z*][A-Za-z*0-9!#$%&'+\-.^_`|~]*$
+/// ```
+///
+/// [token]: <https://httpwg.org/specs/rfc8941.html#token>
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Token(String);
+
+/// A borrowed structured field value [token].
+///
+/// Tokens must match the following regular expression:
+///
+/// ```re
+/// ^[A-Za-z*][A-Za-z*0-9!#$%&'+\-.^_`|~]*$
+/// ```
+///
+/// This type is to [`Token`] as [`str`] is to [`String`].
+///
+/// [token]: <https://httpwg.org/specs/rfc8941.html#token>
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, ref_cast::RefCastCustom)]
+#[repr(transparent)]
+pub struct TokenRef(str);
+
+/// An error produced during conversion to a token.
+#[derive(Debug)]
+pub struct TokenError {
+    byte_index: Option<usize>,
+}
+
+impl fmt::Display for TokenError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(byte_index) = self.byte_index {
+            write!(
+                f,
+                "invalid character for token at byte index {}",
+                byte_index
+            )
+        } else {
+            f.write_str("token cannot be empty")
+        }
+    }
+}
+
+impl std::error::Error for TokenError {}
+
+const fn validate(v: &[u8]) -> Result<(), TokenError> {
+    if v.is_empty() {
+        return Err(TokenError { byte_index: None });
+    }
+
+    if !utils::is_allowed_start_token_char(v[0]) {
+        return Err(TokenError {
+            byte_index: Some(0),
+        });
+    }
+
+    let mut index = 1;
+
+    while index < v.len() {
+        if !utils::is_allowed_inner_token_char(v[index]) {
+            return Err(TokenError {
+                byte_index: Some(index),
+            });
+        }
+        index += 1;
+    }
+
+    Ok(())
+}
+
+impl TokenRef {
+    #[ref_cast::ref_cast_custom]
+    const fn cast(v: &str) -> &Self;
+
+    /// Creates a `&TokenRef` from a `&str`.
+    pub fn from_str(v: &str) -> Result<&Self, TokenError> {
+        validate(v.as_bytes())?;
+        Ok(Self::cast(v))
+    }
+
+    /// Creates a `&TokenRef`, panicking if the value is invalid.
+    ///
+    /// This method is intended to be called from `const` contexts in which the
+    /// value is known to be valid. Use [`TokenRef::from_str`] for non-panicking
+    /// conversions.
+    pub const fn constant(v: &str) -> &Self {
+        match validate(v.as_bytes()) {
+            Ok(_) => Self::cast(v),
+            Err(err) => {
+                if err.byte_index.is_none() {
+                    panic!("token cannot be empty")
+                } else {
+                    panic!("invalid character for token")
+                }
+            }
+        }
+    }
+
+    /// Returns the token as a `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl ToOwned for TokenRef {
+    type Owned = Token;
+
+    fn to_owned(&self) -> Token {
+        Token(self.0.to_owned())
+    }
+}
+
+impl Borrow<TokenRef> for Token {
+    fn borrow(&self) -> &TokenRef {
+        self
+    }
+}
+
+impl std::ops::Deref for Token {
+    type Target = TokenRef;
+
+    fn deref(&self) -> &TokenRef {
+        TokenRef::cast(&self.0)
+    }
+}
+
+impl From<Token> for String {
+    fn from(v: Token) -> String {
+        v.0
+    }
+}
+
+impl TryFrom<String> for Token {
+    type Error = TokenError;
+
+    fn try_from(v: String) -> Result<Token, TokenError> {
+        validate(v.as_bytes())?;
+        Ok(Token(v))
+    }
+}
+
+impl Token {
+    /// Creates a `Token` from a `String`.
+    ///
+    /// Returns the original value if the conversion failed.
+    pub fn from_string(v: String) -> Result<Self, (TokenError, String)> {
+        match validate(v.as_bytes()) {
+            Ok(_) => Ok(Self(v)),
+            Err(err) => Err((err, v)),
+        }
+    }
+}
+
+/// Creates a `&TokenRef`, panicking if the value is invalid.
+///
+/// This is a convenience free function for [`TokenRef::constant`].
+///
+/// This method is intended to be called from `const` contexts in which the
+/// value is known to be valid. Use [`TokenRef::from_str`] for non-panicking
+/// conversions.
+pub const fn token_ref(v: &str) -> &TokenRef {
+    TokenRef::constant(v)
+}
+
+impl fmt::Display for TokenRef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <TokenRef as fmt::Display>::fmt(self, f)
+    }
+}
+
+macro_rules! impl_eq {
+    ($a: ty, $b: ty) => {
+        impl PartialEq<$a> for $b {
+            fn eq(&self, other: &$a) -> bool {
+                <TokenRef as PartialEq>::eq(self, other)
+            }
+        }
+        impl PartialEq<$b> for $a {
+            fn eq(&self, other: &$b) -> bool {
+                <TokenRef as PartialEq>::eq(self, other)
+            }
+        }
+    };
+}
+
+impl_eq!(Token, TokenRef);
+impl_eq!(Token, &TokenRef);
+
+impl<'a> TryFrom<&'a str> for &'a TokenRef {
+    type Error = TokenError;
+
+    fn try_from(v: &'a str) -> Result<&'a TokenRef, TokenError> {
+        TokenRef::from_str(v)
+    }
+}
+
+impl Borrow<str> for Token {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for TokenRef {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,10 +37,10 @@ pub(crate) const fn is_allowed_inner_token_char(c: u8) -> bool {
     is_tchar(c) || c == b':' || c == b'/'
 }
 
-pub(crate) fn is_allowed_start_key_char(c: u8) -> bool {
+pub(crate) const fn is_allowed_start_key_char(c: u8) -> bool {
     c.is_ascii_lowercase() || c == b'*'
 }
 
-pub(crate) fn is_allowed_inner_key_char(c: u8) -> bool {
+pub(crate) const fn is_allowed_inner_key_char(c: u8) -> bool {
     c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, b'_' | b'-' | b'*' | b'.')
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,17 +8,32 @@ pub(crate) const BASE64: engine::GeneralPurpose = engine::GeneralPurpose::new(
         .with_encode_padding(true),
 );
 
-fn is_tchar(c: u8) -> bool {
+const fn is_tchar(c: u8) -> bool {
     // See tchar values list in https://tools.ietf.org/html/rfc7230#section-3.2.6
-    let tchars = b"!#$%&'*+-.^_`|~";
-    tchars.contains(&c) || c.is_ascii_alphanumeric()
+    matches!(
+        c,
+        b'!' | b'#'
+            | b'$'
+            | b'%'
+            | b'&'
+            | b'\''
+            | b'*'
+            | b'+'
+            | b'-'
+            | b'.'
+            | b'^'
+            | b'_'
+            | b'`'
+            | b'|'
+            | b'~'
+    ) || c.is_ascii_alphanumeric()
 }
 
-pub(crate) fn is_allowed_start_token_char(c: u8) -> bool {
+pub(crate) const fn is_allowed_start_token_char(c: u8) -> bool {
     c.is_ascii_alphabetic() || c == b'*'
 }
 
-pub(crate) fn is_allowed_inner_token_char(c: u8) -> bool {
+pub(crate) const fn is_allowed_inner_token_char(c: u8) -> bool {
     is_tchar(c) || c == b':' || c == b'/'
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -12,7 +12,7 @@ fn test_report_to_header() -> Result<(), Box<dyn Error>> {
         .bare_item
         .as_token()
         .ok_or("unexpected BareItem variant")?;
-    assert_eq!(token, "require-corp");
+    assert_eq!(token.as_str(), "require-corp");
 
     let coep_endpoint = coep_parsed
         .params

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -19,7 +19,8 @@ fn test_report_to_header() -> Result<(), Box<dyn Error>> {
         .get("report-to")
         .ok_or("parameter does not exist")?
         .as_str()
-        .ok_or("unexpected BareItem variant")?;
+        .ok_or("unexpected BareItem variant")?
+        .as_str();
 
     let endpoints_parsed = Parser::from_bytes(endpoints).parse_dictionary()?;
     if let Some(ListEntry::Item(item)) = endpoints_parsed.get(coep_endpoint) {
@@ -27,7 +28,7 @@ fn test_report_to_header() -> Result<(), Box<dyn Error>> {
             .bare_item
             .as_str()
             .ok_or("unexpected BareItem variant")?;
-        assert_eq!(item_value, "https://example.com/coep");
+        assert_eq!(item_value.as_str(), "https://example.com/coep");
         return Ok(());
     }
     Err("unexpected endpoint value".into())

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -3,7 +3,10 @@ use serde_json::Value;
 use sfv::FromStr;
 use sfv::Parser;
 use sfv::SerializeValue;
-use sfv::{BareItem, Decimal, Dictionary, InnerList, Item, List, ListEntry, Parameters, TokenRef};
+use sfv::{
+    BareItem, Decimal, Dictionary, InnerList, Item, List, ListEntry, Parameters, StringRef,
+    TokenRef,
+};
 use std::convert::TryInto;
 use std::error::Error;
 use std::path::PathBuf;
@@ -253,10 +256,12 @@ fn build_bare_item(bare_item_value: &Value) -> Result<BareItem, Box<dyn Error>> 
                 .ok_or("build_bare_item: bare_item value is not a bool")?,
         )),
         bare_item if bare_item.is_string() => Ok(BareItem::String(
-            bare_item
-                .as_str()
-                .ok_or("build_bare_item: bare_item value is not a str")?
-                .to_owned(),
+            StringRef::from_str(
+                bare_item
+                    .as_str()
+                    .ok_or("build_bare_item: bare_item value is not a str")?,
+            )?
+            .to_owned(),
         )),
         bare_item if (bare_item.is_object() && bare_item["__type"] == "token") => {
             Ok(BareItem::Token(

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use sfv::FromStr;
 use sfv::Parser;
 use sfv::SerializeValue;
-use sfv::{BareItem, Decimal, Dictionary, InnerList, Item, List, ListEntry, Parameters};
+use sfv::{BareItem, Decimal, Dictionary, InnerList, Item, List, ListEntry, Parameters, TokenRef};
 use std::convert::TryInto;
 use std::error::Error;
 use std::path::PathBuf;
@@ -260,10 +260,12 @@ fn build_bare_item(bare_item_value: &Value) -> Result<BareItem, Box<dyn Error>> 
         )),
         bare_item if (bare_item.is_object() && bare_item["__type"] == "token") => {
             Ok(BareItem::Token(
-                bare_item["value"]
-                    .as_str()
-                    .ok_or("build_bare_item: bare_item value is not a str")?
-                    .to_owned(),
+                TokenRef::from_str(
+                    bare_item["value"]
+                        .as_str()
+                        .ok_or("build_bare_item: bare_item value is not a str")?,
+                )?
+                .to_owned(),
             ))
         }
         bare_item if (bare_item.is_object() && bare_item["__type"] == "binary") => {

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -1,13 +1,12 @@
 use serde::Deserialize;
 use serde_json::Value;
-use sfv::FromStr;
 use sfv::Parser;
 use sfv::SerializeValue;
 use sfv::{
     BareItem, Decimal, Dictionary, InnerList, Item, KeyRef, List, ListEntry, Parameters, StringRef,
     TokenRef,
 };
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::error::Error;
 use std::path::PathBuf;
 use std::{env, fs};
@@ -249,7 +248,7 @@ fn build_bare_item(bare_item_value: &Value) -> Result<BareItem, Box<dyn Error>> 
                 .try_into()?,
         )),
         bare_item if bare_item.is_f64() => {
-            let decimal = Decimal::from_str(&serde_json::to_string(bare_item)?)?;
+            let decimal = Decimal::try_from(bare_item.as_f64().unwrap())?;
             Ok(BareItem::Decimal(decimal))
         }
         bare_item if bare_item.is_boolean() => Ok(BareItem::Boolean(

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -4,7 +4,7 @@ use sfv::FromStr;
 use sfv::Parser;
 use sfv::SerializeValue;
 use sfv::{
-    BareItem, Decimal, Dictionary, InnerList, Item, List, ListEntry, Parameters, StringRef,
+    BareItem, Decimal, Dictionary, InnerList, Item, KeyRef, List, ListEntry, Parameters, StringRef,
     TokenRef,
 };
 use std::convert::TryInto;
@@ -171,9 +171,11 @@ fn build_dict(expected_value: &Value) -> Result<Dictionary, Box<dyn Error>> {
         let member = member
             .as_array()
             .ok_or("build_dict: expected dict member is not an array")?;
-        let member_name = member[0]
-            .as_str()
-            .ok_or("build_dict: expected dict member name is not a str")?;
+        let member_name = KeyRef::from_str(
+            member[0]
+                .as_str()
+                .ok_or("build_dict: expected dict member name is not a str")?,
+        )?;
         let member_value = &member[1];
         let item_or_inner_list: ListEntry = build_list_or_item(member_value)?;
         dict.insert(member_name.to_owned(), item_or_inner_list);
@@ -300,9 +302,11 @@ fn build_parameters(params_value: &Value) -> Result<Parameters, Box<dyn Error>> 
         let member = member
             .as_array()
             .ok_or("build_parameters: expected parameter is not an array")?;
-        let key = member[0]
-            .as_str()
-            .ok_or("build_parameters: expected parameter name is not a str")?;
+        let key = KeyRef::from_str(
+            member[0]
+                .as_str()
+                .ok_or("build_parameters: expected parameter name is not a str")?,
+        )?;
         let value = &member[1];
         let itm = build_bare_item(value)?;
         parameters.insert(key.to_owned(), itm);


### PR DESCRIPTION
This is an updated version of #102 that takes the following approach:

1. `BareItem` and `RefBareItem` contain only fully validated types.
2. Dictionary and parameter keys are likewise fully validated.
3. A number of helpers based on `Into` and `TryInto` simplify creation of these types from unvalidated inputs, including at compile-time using `const fn`.
4. Parsing produces these fully validated types.
5. Serialization accepts only these fully validated types, making serialization in general infallible (the only real errors being empty list and empty dictionary) and presumably improving performance in the likely common case that components are fully validated at compile time.
6. `rust_decimal::Decimal` is replaced with an `sfv::Decimal` type that simply wraps the new `Integer` type, as an [SFV decimal](https://httpwg.org/specs/rfc8941.html#decimal) is 12 integral digits and 3 fractional digits, while an [SFV integer](https://httpwg.org/specs/rfc8941.html#integer) is 15 decimal digits.
7. The new `sfv::{Key, String, Token}` types are the owned equivalents of the new `sfv::{KeyRef, StringRef, TokenRef}` types, analogous to `Vec<T>` vs `[T]`.

As part of #119, we will likewise introduce an `sfv::Date` type that wraps `Integer`.

Fixes #98 