### PR TITLE
Revert "Improve readability of doc examples (#138)"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ assert!(item.is_ok());
 println!("{:#?}", item);
 
 // Parsing structured field value of List type.
-let list_header_input = r#"1;a=tok, ("foo" "bar");baz, ()"#;
+let list_header_input = "1;a=tok, (\"foo\" \"bar\");baz, ()";
 let list = Parser::from_str(list_header_input).parse_list();
 assert!(list.is_ok());
 println!("{:#?}", list);
@@ -101,7 +101,7 @@ Creates `Item` with empty parameters:
 use sfv::{Item, BareItem, SerializeValue};
 
 let str_item = Item::new(BareItem::String(String::from("foo")));
-assert_eq!(str_item.serialize_value().unwrap(), r#""foo""#);
+assert_eq!(str_item.serialize_value().unwrap(), "\"foo\"");
 ```
 
 
@@ -139,7 +139,7 @@ let inner_list = InnerList::with_params(vec![int_item, str_item], inner_list_par
 let list: List = vec![Item::new(tok_item).into(), inner_list.into()];
 assert_eq!(
     list.serialize_value().unwrap(),
-    r#"tok, (99;key=?0 "foo");bar"#
+    "tok, (99;key=?0 \"foo\");bar"
 );
 ```
 
@@ -158,7 +158,7 @@ dict.insert("key3".into(), member_value3.into());
 
 assert_eq!(
     dict.serialize_value().unwrap(),
-    r#"key1="apple", key2, key3=?0"#
+    "key1=\"apple\", key2, key3=?0"
 );
 
 ```

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,18 +17,12 @@ pub trait ParseMore {
     /// parses and merges next line into a single structured field value.
     /// # Examples
     /// ```
-    /// # use sfv::{ParseMore, Parser, SerializeValue};
-    /// # fn main() -> Result<(), &'static str> {
-    /// let mut list_field = Parser::from_str("11, (12 13)").parse_list()?;
+    /// # use sfv::{Parser, SerializeValue, ParseMore};
     ///
-    /// list_field.parse_more(r#""foo",        "bar""#.as_bytes())?;
+    /// let mut list_field = Parser::from_str("11, (12 13)").parse_list().unwrap();
+    /// list_field.parse_more("\"foo\",        \"bar\"".as_bytes()).unwrap();
     ///
-    /// assert_eq!(
-    ///     list_field.serialize_value()?,
-    ///     r#"11, (12 13), "foo", "bar""#,
-    /// );
-    /// # Ok(())
-    /// # }
+    /// assert_eq!(list_field.serialize_value().unwrap(), "11, (12 13), \"foo\", \"bar\"");
     /// ```
     fn parse_more(&mut self, input_bytes: &[u8]) -> SFVResult<()>
     where

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -6,16 +6,14 @@ use std::marker::PhantomData;
 /// ```
 /// use sfv::RefItemSerializer;
 ///
-/// # fn main() -> Result<(), &'static str> {
 /// let mut serialized_item = String::new();
-///
-/// RefItemSerializer::new(&mut serialized_item)
-///   .bare_item(11)?
-///   .parameter("foo", true)?;
-///
+/// let serializer = RefItemSerializer::new(&mut serialized_item);
+/// serializer
+/// .bare_item(11)
+/// .unwrap()
+/// .parameter("foo", true)
+/// .unwrap();
 /// assert_eq!(serialized_item, "11;foo");
-/// # Ok(())
-/// # }
 /// ```
 #[derive(Debug)]
 pub struct RefItemSerializer<'a> {
@@ -52,25 +50,27 @@ impl RefParameterSerializer<'_> {
 /// ```
 /// use sfv::{RefBareItem, RefListSerializer};
 ///
-/// # fn main() -> Result<(), &'static str> {
 /// let mut serialized_item = String::new();
-///
-/// RefListSerializer::new(&mut serialized_item)
-///     .bare_item(11)?
-///     .parameter("foo", true)?
+/// let serializer = RefListSerializer::new(&mut serialized_item);
+/// serializer
+///     .bare_item(11)
+///     .unwrap()
+///     .parameter("foo", true)
+///     .unwrap()
 ///     .open_inner_list()
-///     .inner_list_bare_item(RefBareItem::Token("abc"))?
-///     .inner_list_parameter("abc_param", false)?
-///     .inner_list_bare_item(RefBareItem::Token("def"))?
+///     .inner_list_bare_item(RefBareItem::Token("abc"))
+///     .unwrap()
+///     .inner_list_parameter("abc_param", false)
+///     .unwrap()
+///     .inner_list_bare_item(RefBareItem::Token("def"))
+///     .unwrap()
 ///     .close_inner_list()
-///     .parameter("bar", RefBareItem::String("val"))?;
-///
+///     .parameter("bar", RefBareItem::String("val"))
+///     .unwrap();
 /// assert_eq!(
 ///     serialized_item,
-///     r#"11;foo, (abc;abc_param=?0 def);bar="val""#
+///     "11;foo, (abc;abc_param=?0 def);bar=\"val\""
 /// );
-/// # Ok(())
-/// # }
 /// ```
 #[derive(Debug)]
 pub struct RefListSerializer<'a> {
@@ -117,31 +117,35 @@ impl<'a> RefListSerializer<'a> {
 
 /// Serializes `Dictionary` field value components incrementally.
 /// ```
-/// use sfv::{Decimal, FromPrimitive, RefBareItem, RefDictSerializer};
+/// use sfv::{RefBareItem, RefDictSerializer, Decimal, FromPrimitive};
 ///
-/// # fn main() -> Result<(), &'static str> {
 /// let mut serialized_item = String::new();
-///
-/// RefDictSerializer::new(&mut serialized_item)
-///    .bare_item_member("member1", 11)?
-///    .parameter("foo", true)?
-///    .open_inner_list("member2")?
-///    .inner_list_bare_item(RefBareItem::Token("abc"))?
-///    .inner_list_parameter("abc_param", false)?
-///    .inner_list_bare_item(RefBareItem::Token("def"))?
+/// let serializer = RefDictSerializer::new(&mut serialized_item);
+/// serializer
+///    .bare_item_member("member1", 11)
+///    .unwrap()
+///    .parameter("foo", true)
+///    .unwrap()
+///    .open_inner_list("member2")
+///    .unwrap()
+///    .inner_list_bare_item(RefBareItem::Token("abc"))
+///    .unwrap()
+///    .inner_list_parameter("abc_param", false)
+///    .unwrap()
+///    .inner_list_bare_item(RefBareItem::Token("def"))
+///    .unwrap()
 ///    .close_inner_list()
-///    .parameter("bar", RefBareItem::String("val"))?
+///    .parameter("bar", RefBareItem::String("val"))
+///    .unwrap()
 ///    .bare_item_member(
 ///         "member3",
 ///         Decimal::from_f64(12.34566).unwrap(),
-///    )?;
-///
+///    )
+///    .unwrap();
 /// assert_eq!(
 ///    serialized_item,
-///    r#"member1=11;foo, member2=(abc;abc_param=?0 def);bar="val", member3=12.346"#
+///    "member1=11;foo, member2=(abc;abc_param=?0 def);bar=\"val\", member3=12.346"
 /// );
-/// # Ok(())
-/// # }
 /// ```
 #[derive(Debug)]
 pub struct RefDictSerializer<'a> {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -11,15 +11,14 @@ pub trait SerializeValue {
     /// # Examples
     /// ```
     /// # use sfv::{Parser, SerializeValue};
-    /// # fn main() -> Result<(), &'static str> {
-    /// let parsed_list_field = Parser::from_str(r#" "london",   "berlin" "#).parse_list()?;
+    ///
+    /// let parsed_list_field = Parser::from_str("\"london\", \t\t\"berlin\"").parse_list();
+    /// assert!(parsed_list_field.is_ok());
     ///
     /// assert_eq!(
-    ///     parsed_list_field.serialize_value()?,
-    ///     r#""london", "berlin""#
+    ///     parsed_list_field.unwrap().serialize_value().unwrap(),
+    ///     "\"london\", \"berlin\""
     /// );
-    /// # Ok(())
-    /// # }
     /// ```
     fn serialize_value(&self) -> SFVResult<String>;
 }


### PR DESCRIPTION
This reverts commit 6d94c8f741563e1a537e8c864c459fcd1e4567fe.

I think #127 caused #138 to fail.
I'll back it out for now. @apasel422 - could you give #138 another shot?