### PR TITLE
Improve readability of doc examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ assert!(item.is_ok());
 println!("{:#?}", item);
 
 // Parsing structured field value of List type.
-let list_header_input = "1;a=tok, (\"foo\" \"bar\");baz, ()";
+let list_header_input = r#"1;a=tok, ("foo" "bar");baz, ()"#;
 let list = Parser::from_str(list_header_input).parse_list();
 assert!(list.is_ok());
 println!("{:#?}", list);
@@ -101,7 +101,7 @@ Creates `Item` with empty parameters:
 use sfv::{Item, BareItem, SerializeValue};
 
 let str_item = Item::new(BareItem::String(String::from("foo")));
-assert_eq!(str_item.serialize_value().unwrap(), "\"foo\"");
+assert_eq!(str_item.serialize_value().unwrap(), r#""foo""#);
 ```
 
 
@@ -139,7 +139,7 @@ let inner_list = InnerList::with_params(vec![int_item, str_item], inner_list_par
 let list: List = vec![Item::new(tok_item).into(), inner_list.into()];
 assert_eq!(
     list.serialize_value().unwrap(),
-    "tok, (99;key=?0 \"foo\");bar"
+    r#"tok, (99;key=?0 "foo");bar"#
 );
 ```
 
@@ -158,7 +158,7 @@ dict.insert("key3".into(), member_value3.into());
 
 assert_eq!(
     dict.serialize_value().unwrap(),
-    "key1=\"apple\", key2, key3=?0"
+    r#"key1="apple", key2, key3=?0"#
 );
 
 ```

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,11 +21,11 @@ pub trait ParseMore {
     /// # fn main() -> Result<(), sfv::Error> {
     /// let mut list_field = Parser::from_str("11, (12 13)").parse_list()?;
     ///
-    /// list_field.parse_more("\"foo\",        \"bar\"".as_bytes())?;
+    /// list_field.parse_more(r#""foo",        "bar""#.as_bytes())?;
     ///
     /// assert_eq!(
     ///     list_field.serialize_value()?,
-    ///     "11, (12 13), \"foo\", \"bar\"",
+    ///     r#"11, (12 13), "foo", "bar""#,
     /// );
     /// # Ok(())
     /// # }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,12 +17,18 @@ pub trait ParseMore {
     /// parses and merges next line into a single structured field value.
     /// # Examples
     /// ```
-    /// # use sfv::{Parser, SerializeValue, ParseMore};
+    /// # use sfv::{ParseMore, Parser, SerializeValue};
+    /// # fn main() -> Result<(), sfv::Error> {
+    /// let mut list_field = Parser::from_str("11, (12 13)").parse_list()?;
     ///
-    /// let mut list_field = Parser::from_str("11, (12 13)").parse_list().unwrap();
-    /// list_field.parse_more("\"foo\",        \"bar\"".as_bytes()).unwrap();
+    /// list_field.parse_more("\"foo\",        \"bar\"".as_bytes())?;
     ///
-    /// assert_eq!(list_field.serialize_value().unwrap(), "11, (12 13), \"foo\", \"bar\"");
+    /// assert_eq!(
+    ///     list_field.serialize_value()?,
+    ///     "11, (12 13), \"foo\", \"bar\"",
+    /// );
+    /// # Ok(())
+    /// # }
     /// ```
     fn parse_more(&mut self, input_bytes: &[u8]) -> SFVResult<()>
     where

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -91,7 +91,7 @@ fn maybe_write_separator(buffer: &mut String, first: &mut bool) {
 ///
 /// assert_eq!(
 ///     serialized_list,
-///     "11;foo, (abc;abc_param=?0 def);bar=\"val\""
+///     r#"11;foo, (abc;abc_param=?0 def);bar="val""#
 /// );
 /// # Ok(())
 /// # }
@@ -173,7 +173,7 @@ impl<W: BorrowMut<String>> RefListSerializer<W> {
 ///
 /// assert_eq!(
 ///    serialized_dict,
-///    "member1=11;foo, member2=(abc;abc_param=?0 def);bar=\"val\", member3=12.346"
+///    r#"member1=11;foo, member2=(abc;abc_param=?0 def);bar="val", member3=12.346"#
 /// );
 /// # Ok(())
 /// # }

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -7,13 +7,15 @@ use std::borrow::BorrowMut;
 /// ```
 /// use sfv::RefItemSerializer;
 ///
+/// # fn main() -> Result<(), sfv::Error> {
 /// let serialized_item = RefItemSerializer::new()
-///     .bare_item(11)
-///     .unwrap()
-///     .parameter("foo", true)
-///     .unwrap()
+///     .bare_item(11)?
+///     .parameter("foo", true)?
 ///     .finish();
+///
 /// assert_eq!(serialized_item, "11;foo");
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug)]
 pub struct RefItemSerializer<W> {
@@ -75,27 +77,24 @@ fn maybe_write_separator(buffer: &mut String, first: &mut bool) {
 /// ```
 /// use sfv::{RefBareItem, RefListSerializer};
 ///
+/// # fn main() -> Result<(), sfv::Error> {
 /// let serialized_list = RefListSerializer::new()
-///     .bare_item(11)
-///     .unwrap()
-///     .parameter("foo", true)
-///     .unwrap()
+///     .bare_item(11)?
+///     .parameter("foo", true)?
 ///     .open_inner_list()
-///     .inner_list_bare_item(RefBareItem::Token("abc"))
-///     .unwrap()
-///     .inner_list_parameter("abc_param", false)
-///     .unwrap()
-///     .inner_list_bare_item(RefBareItem::Token("def"))
-///     .unwrap()
+///     .inner_list_bare_item(RefBareItem::Token("abc"))?
+///     .inner_list_parameter("abc_param", false)?
+///     .inner_list_bare_item(RefBareItem::Token("def"))?
 ///     .close_inner_list()
-///     .parameter("bar", RefBareItem::String("val"))
-///     .unwrap()
-///     .finish()
-///     .unwrap();
+///     .parameter("bar", RefBareItem::String("val"))?
+///     .finish()?;
+///
 /// assert_eq!(
 ///     serialized_list,
 ///     "11;foo, (abc;abc_param=?0 def);bar=\"val\""
 /// );
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug)]
 pub struct RefListSerializer<W> {
@@ -154,35 +153,30 @@ impl<W: BorrowMut<String>> RefListSerializer<W> {
 
 /// Serializes `Dictionary` field value components incrementally.
 /// ```
-/// use sfv::{RefBareItem, RefDictSerializer, Decimal, FromPrimitive};
+/// use sfv::{Decimal, FromPrimitive, RefBareItem, RefDictSerializer};
 ///
+/// # fn main() -> Result<(), sfv::Error> {
 /// let serialized_dict = RefDictSerializer::new()
-///    .bare_item_member("member1", 11)
-///    .unwrap()
-///    .parameter("foo", true)
-///    .unwrap()
-///    .open_inner_list("member2")
-///    .unwrap()
-///    .inner_list_bare_item(RefBareItem::Token("abc"))
-///    .unwrap()
-///    .inner_list_parameter("abc_param", false)
-///    .unwrap()
-///    .inner_list_bare_item(RefBareItem::Token("def"))
-///    .unwrap()
+///    .bare_item_member("member1", 11)?
+///    .parameter("foo", true)?
+///    .open_inner_list("member2")?
+///    .inner_list_bare_item(RefBareItem::Token("abc"))?
+///    .inner_list_parameter("abc_param", false)?
+///    .inner_list_bare_item(RefBareItem::Token("def"))?
 ///    .close_inner_list()
-///    .parameter("bar", RefBareItem::String("val"))
-///    .unwrap()
+///    .parameter("bar", RefBareItem::String("val"))?
 ///    .bare_item_member(
 ///         "member3",
 ///         Decimal::from_f64(12.34566).unwrap(),
-///    )
-///    .unwrap()
-///    .finish()
-///    .unwrap();
+///    )?
+///    .finish()?;
+///
 /// assert_eq!(
 ///    serialized_dict,
 ///    "member1=11;foo, member2=(abc;abc_param=?0 def);bar=\"val\", member3=12.346"
 /// );
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug)]
 pub struct RefDictSerializer<W> {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -12,11 +12,11 @@ pub trait SerializeValue {
     /// ```
     /// # use sfv::{Parser, SerializeValue};
     /// # fn main() -> Result<(), sfv::Error> {
-    /// let parsed_list_field = Parser::from_str("\"london\", \t\t\"berlin\"").parse_list()?;
+    /// let parsed_list_field = Parser::from_str(r#" "london",   "berlin" "#).parse_list()?;
     ///
     /// assert_eq!(
     ///     parsed_list_field.serialize_value()?,
-    ///     "\"london\", \"berlin\""
+    ///     r#""london", "berlin""#
     /// );
     /// # Ok(())
     /// # }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -11,14 +11,15 @@ pub trait SerializeValue {
     /// # Examples
     /// ```
     /// # use sfv::{Parser, SerializeValue};
-    ///
-    /// let parsed_list_field = Parser::from_str("\"london\", \t\t\"berlin\"").parse_list();
-    /// assert!(parsed_list_field.is_ok());
+    /// # fn main() -> Result<(), sfv::Error> {
+    /// let parsed_list_field = Parser::from_str("\"london\", \t\t\"berlin\"").parse_list()?;
     ///
     /// assert_eq!(
-    ///     parsed_list_field.unwrap().serialize_value().unwrap(),
+    ///     parsed_list_field.serialize_value()?,
     ///     "\"london\", \"berlin\""
     /// );
+    /// # Ok(())
+    /// # }
     /// ```
     fn serialize_value(&self) -> SFVResult<String>;
 }


### PR DESCRIPTION
1. Replace most uses of `unwrap` with `?`
2. Use raw strings to avoid escaping quotes and to make serialized values directly copy-pasteable

This is a reland of #138.