### PR TITLE
Remove Ref prefix from serializer types

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,8 +3,8 @@ extern crate criterion;
 
 use criterion::{BenchmarkId, Criterion};
 use sfv::{
-    integer, key_ref, string_ref, token_ref, Decimal, Parser, RefDictSerializer, RefItemSerializer,
-    RefListSerializer, SerializeValue,
+    integer, key_ref, string_ref, token_ref, Decimal, DictSerializer, ItemSerializer,
+    ListSerializer, Parser, SerializeValue,
 };
 use std::convert::TryFrom;
 
@@ -105,7 +105,7 @@ fn serializing_ref_item(c: &mut Criterion) {
         &fixture,
         move |bench, &input| {
             bench.iter(|| {
-                let ser = RefItemSerializer::new();
+                let ser = ItemSerializer::new();
                 ser.bare_item(input.as_bytes()).finish()
             });
         },
@@ -115,7 +115,7 @@ fn serializing_ref_item(c: &mut Criterion) {
 fn serializing_ref_list(c: &mut Criterion) {
     c.bench_function("serializing_ref_list", move |bench| {
         bench.iter(|| {
-            let ser = RefListSerializer::new();
+            let ser = ListSerializer::new();
             ser.bare_item(token_ref("a"))
                 .bare_item(token_ref("abcdefghigklmnoprst"))
                 .bare_item(integer(123456785686457))
@@ -140,7 +140,7 @@ fn serializing_ref_list(c: &mut Criterion) {
 fn serializing_ref_dict(c: &mut Criterion) {
     c.bench_function("serializing_ref_dict", move |bench| {
         bench.iter(|| {
-            RefDictSerializer::new()
+            DictSerializer::new()
                 .bare_item_member(key_ref("a"), true)
                 .bare_item_member(key_ref("dict_key2"), token_ref("abcdefghigklmnoprst"))
                 .bare_item_member(key_ref("dict_key3"), integer(123456785686457))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,8 +211,7 @@ pub use integer::{integer, Integer, OutOfRangeError};
 pub use key::{key_ref, Key, KeyError, KeyRef};
 pub use parser::{ParseMore, Parser};
 pub use ref_serializer::{
-    RefDictSerializer, RefInnerListSerializer, RefItemSerializer, RefListSerializer,
-    RefParameterSerializer,
+    DictSerializer, InnerListSerializer, ItemSerializer, ListSerializer, ParameterSerializer,
 };
 pub use serializer::SerializeValue;
 pub use string::{string_ref, String, StringError, StringRef};
@@ -514,7 +513,7 @@ pub(crate) enum Num {
 /// `BareItem` type is used to construct `Items` or `Parameters` values.
 pub type BareItem = GenericBareItem<String, Vec<u8>, Token>;
 
-/// Similar to `BareItem`, but used to serialize values via `RefItemSerializer`, `RefListSerializer`, `RefDictSerializer`.
+/// Similar to `BareItem`, but used to serialize values via `ItemSerializer`, `ListSerializer`, `DictSerializer`.
 pub type RefBareItem<'a> = GenericBareItem<&'a StringRef, &'a [u8], &'a TokenRef>;
 
 impl<'a, S, B, T> From<&'a GenericBareItem<S, B, T>> for RefBareItem<'a>


### PR DESCRIPTION
It's essentially meaningless now that they can serialize into owned Strings.