### PR TITLE
Reorganize serializers

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -115,24 +115,23 @@ fn serializing_ref_item(c: &mut Criterion) {
 fn serializing_ref_list(c: &mut Criterion) {
     c.bench_function("serializing_ref_list", move |bench| {
         bench.iter(|| {
-            let ser = RefListSerializer::new();
-            ser.bare_item(token_ref("a"))
-                .bare_item(token_ref("abcdefghigklmnoprst"))
-                .bare_item(integer(123456785686457))
-                .bare_item(Decimal::try_from(99999999999.999).unwrap())
-                .open_inner_list()
-                .close_inner_list()
-                .open_inner_list()
-                .inner_list_bare_item(string_ref("somelongstringvalue"))
-                .inner_list_bare_item(string_ref("anotherlongstringvalue"))
-                .inner_list_parameter(
-                    key_ref("key"),
-                    "somever longstringvaluerepresentedasbytes".as_bytes(),
-                )
-                .unwrap()
-                .inner_list_bare_item(145)
-                .close_inner_list()
-                .finish()
+            let mut ser = RefListSerializer::new();
+            ser.bare_item(token_ref("a"));
+            ser.bare_item(token_ref("abcdefghigklmnoprst"));
+            ser.bare_item(integer(123456785686457));
+            ser.bare_item(Decimal::try_from(99999999999.999).unwrap());
+            ser.inner_list();
+            {
+                let mut ser = ser.inner_list();
+                ser.bare_item(string_ref("somelongstringvalue"));
+                ser.bare_item(string_ref("anotherlongstringvalue"))
+                    .parameter(
+                        key_ref("key"),
+                        "somever longstringvaluerepresentedasbytes".as_bytes(),
+                    );
+                ser.bare_item(145);
+            }
+            ser.finish()
         });
     });
 }
@@ -140,17 +139,18 @@ fn serializing_ref_list(c: &mut Criterion) {
 fn serializing_ref_dict(c: &mut Criterion) {
     c.bench_function("serializing_ref_dict", move |bench| {
         bench.iter(|| {
-            RefDictSerializer::new()
-                .bare_item_member(key_ref("a"), true)
-                .bare_item_member(key_ref("dict_key2"), token_ref("abcdefghigklmnoprst"))
-                .bare_item_member(key_ref("dict_key3"), integer(123456785686457))
-                .open_inner_list(key_ref("dict_key4"))
-                .inner_list_bare_item(string_ref("inner-list-member"))
-                .inner_list_bare_item("inner-list-member".as_bytes())
-                .close_inner_list()
-                .parameter(key_ref("key"), token_ref("aW5uZXItbGlzdC1wYXJhbWV0ZXJz"))
-                .unwrap()
-                .finish()
+            let mut ser = RefDictSerializer::new();
+            ser.bare_item(key_ref("a"), true);
+            ser.bare_item(key_ref("dict_key2"), token_ref("abcdefghigklmnoprst"));
+            ser.bare_item(key_ref("dict_key3"), integer(123456785686457));
+            {
+                let mut ser = ser.inner_list(key_ref("dict_key4"));
+                ser.bare_item(string_ref("inner-list-member"));
+                ser.bare_item("inner-list-member".as_bytes());
+                ser.finish()
+                    .parameter(key_ref("key"), token_ref("aW5uZXItbGlzdC1wYXJhbWV0ZXJz"));
+            }
+            ser.finish()
         });
     });
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -230,6 +230,18 @@ impl Borrow<str> for KeyRef {
     }
 }
 
+impl AsRef<KeyRef> for Key {
+    fn as_ref(&self) -> &KeyRef {
+        self
+    }
+}
+
+impl AsRef<KeyRef> for KeyRef {
+    fn as_ref(&self) -> &KeyRef {
+        self
+    }
+}
+
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for &'a KeyRef {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,7 +1,6 @@
 use crate::utils;
 use crate::{
-    BareItem, Decimal, Dictionary, Error, InnerList, Integer, Item, KeyRef, List, ListEntry,
-    Parameters, RefBareItem, SFVResult, StringRef, TokenRef,
+    Decimal, Dictionary, Integer, Item, KeyRef, List, RefBareItem, SFVResult, StringRef, TokenRef,
 };
 use std::fmt::Write as _;
 
@@ -26,25 +25,26 @@ pub trait SerializeValue {
 
 impl SerializeValue for Dictionary {
     fn serialize_value(&self) -> SFVResult<String> {
-        let mut output = String::new();
-        Serializer::serialize_dict(self, &mut output)?;
-        Ok(output)
+        let mut ser = crate::RefDictSerializer::new();
+        ser.members(self);
+        ser.finish()
     }
 }
 
 impl SerializeValue for List {
     fn serialize_value(&self) -> SFVResult<String> {
-        let mut output = String::new();
-        Serializer::serialize_list(self, &mut output)?;
-        Ok(output)
+        let mut ser = crate::RefListSerializer::new();
+        ser.members(self);
+        ser.finish()
     }
 }
 
 impl SerializeValue for Item {
     fn serialize_value(&self) -> SFVResult<String> {
-        let mut output = String::new();
-        Serializer::serialize_item(self, &mut output);
-        Ok(output)
+        Ok(crate::RefItemSerializer::new()
+            .bare_item(&self.bare_item)
+            .parameters(&self.params)
+            .finish())
     }
 }
 
@@ -52,98 +52,6 @@ impl SerializeValue for Item {
 pub(crate) struct Serializer;
 
 impl Serializer {
-    pub(crate) fn serialize_item(input_item: &Item, output: &mut String) {
-        // https://httpwg.org/specs/rfc8941.html#ser-item
-
-        Self::serialize_bare_item(&input_item.bare_item, output);
-        Self::serialize_parameters(&input_item.params, output);
-    }
-
-    pub(crate) fn serialize_list(input_list: &List, output: &mut String) -> SFVResult<()> {
-        // https://httpwg.org/specs/rfc8941.html#ser-list
-        if input_list.is_empty() {
-            return Err(Error::new(
-                "serialize_list: serializing empty field is not allowed",
-            ));
-        }
-
-        for (idx, member) in input_list.iter().enumerate() {
-            match member {
-                ListEntry::Item(item) => {
-                    Self::serialize_item(item, output);
-                }
-                ListEntry::InnerList(inner_list) => {
-                    Self::serialize_inner_list(inner_list, output);
-                }
-            }
-
-            // If more items remain in input_list:
-            //      Append “,” to output.
-            //      Append a single SP to output.
-            if idx < input_list.len() - 1 {
-                output.push_str(", ");
-            }
-        }
-        Ok(())
-    }
-
-    pub(crate) fn serialize_dict(input_dict: &Dictionary, output: &mut String) -> SFVResult<()> {
-        // https://httpwg.org/specs/rfc8941.html#ser-dictionary
-        if input_dict.is_empty() {
-            return Err(Error::new(
-                "serialize_dictionary: serializing empty field is not allowed",
-            ));
-        }
-
-        for (idx, (member_name, member_value)) in input_dict.iter().enumerate() {
-            Serializer::serialize_key(member_name, output);
-
-            match member_value {
-                ListEntry::Item(item) => {
-                    // If dict member is boolean true, no need to serialize it: only its params must be serialized
-                    // Otherwise serialize entire item with its params
-                    if item.bare_item == BareItem::Boolean(true) {
-                        Self::serialize_parameters(&item.params, output);
-                    } else {
-                        output.push('=');
-                        Self::serialize_item(item, output);
-                    }
-                }
-                ListEntry::InnerList(inner_list) => {
-                    output.push('=');
-                    Self::serialize_inner_list(inner_list, output);
-                }
-            }
-
-            // If more items remain in input_dictionary:
-            //      Append “,” to output.
-            //      Append a single SP to output.
-            if idx < input_dict.len() - 1 {
-                output.push_str(", ");
-            }
-        }
-        Ok(())
-    }
-
-    fn serialize_inner_list(input_inner_list: &InnerList, output: &mut String) {
-        // https://httpwg.org/specs/rfc8941.html#ser-innerlist
-
-        let items = &input_inner_list.items;
-        let inner_list_parameters = &input_inner_list.params;
-
-        output.push('(');
-        for (idx, item) in items.iter().enumerate() {
-            Self::serialize_item(item, output);
-
-            // If more values remain in inner_list, append a single SP to output
-            if idx < items.len() - 1 {
-                output.push(' ');
-            }
-        }
-        output.push(')');
-        Self::serialize_parameters(inner_list_parameters, output);
-    }
-
     pub(crate) fn serialize_bare_item<'b>(value: impl Into<RefBareItem<'b>>, output: &mut String) {
         // https://httpwg.org/specs/rfc8941.html#ser-bare-item
 
@@ -157,19 +65,12 @@ impl Serializer {
         }
     }
 
-    pub(crate) fn serialize_parameters(input_params: &Parameters, output: &mut String) {
-        // https://httpwg.org/specs/rfc8941.html#ser-params
-
-        for (param_name, param_value) in input_params {
-            Self::serialize_parameter(param_name, param_value, output);
-        }
-    }
-
     pub(crate) fn serialize_parameter<'b>(
         name: &KeyRef,
         value: impl Into<RefBareItem<'b>>,
         output: &mut String,
     ) {
+        // https://httpwg.org/specs/rfc8941.html#ser-params
         output.push(';');
         Self::serialize_key(name, output);
 


### PR DESCRIPTION
1. Ensure that serializers can be used with owned and borrowed strings. This was an oversight in #133.
2. Share the serialization code between fully parsed structures and the incremental serializers.
3. Remove the unnecessary `Ref` prefix from the serializer types.