### PR TITLE
Make indexmap an optional dependency

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,6 +26,14 @@ jobs:
         with:
           command: check
           args: --all-targets
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-targets --no-default-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-targets --all-features
 
   test:
     name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["tests/**", ".github/*"]
 [dependencies]
 arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
 base64 = "0.22.1"
-indexmap = "2"
+indexmap = { version = "2", optional = true }
 ref-cast = "1.0.23"
 
 [dev-dependencies]
@@ -27,6 +27,17 @@ base32 = "0.5.1"
 [[bench]]
 name = "bench"
 harness = false
+required-features = ["parsed-types"]
 
 [features]
+default = ["parsed-types"]
 arbitrary = ["dep:arbitrary", "indexmap/arbitrary"]
+parsed-types = ["dep:indexmap"]
+
+[[test]]
+name = "integration_tests"
+required-features = ["parsed-types"]
+
+[[test]]
+name = "specification_tests"
+required-features = ["parsed-types"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,10 @@ There's also a few primitive types used to construct structured field values:
 - `Parameters` are an ordered map of key-value pairs that are associated with an `Item` or `InnerList`. The keys are unique within the scope the `Parameters` they occur within, and the values are `BareItem`.
 - `InnerList` is an array of zero or more `Items`. Can have `Parameters`.
 - `ListEntry` represents either `Item` or `InnerList` as a member of `List` or as member-value in `Dictionary`.
-
+*/
+#![cfg_attr(
+    feature = "parsed-types",
+    doc = r##"
 # Examples
 
 ### Parsing
@@ -173,12 +176,14 @@ assert_eq!(
 # Ok(())
 # }
 ```
-*/
+"##
+)]
 
 mod decimal;
 mod error;
 mod integer;
 mod key;
+#[cfg(feature = "parsed-types")]
 mod parsed;
 mod parser;
 mod ref_serializer;
@@ -215,11 +220,14 @@ pub use ref_serializer::{
     RefDictSerializer, RefInnerListSerializer, RefItemSerializer, RefListSerializer,
     RefParameterSerializer,
 };
-pub use serializer::SerializeValue;
 pub use string::{string_ref, String, StringError, StringRef};
 pub use token::{token_ref, Token, TokenError, TokenRef};
 
+#[cfg(feature = "parsed-types")]
 pub use parsed::{Dictionary, InnerList, Item, List, ListEntry, Parameters};
+
+#[cfg(feature = "parsed-types")]
+pub use serializer::SerializeValue;
 
 type SFVResult<T> = std::result::Result<T, Error>;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,9 +1,11 @@
 use crate::utils;
 use crate::visitor::*;
 use crate::{
-    BareItemFromInput, Decimal, Dictionary, Error, Integer, Item, KeyRef, List, Num, SFVResult,
-    String, StringRef, TokenRef,
+    BareItemFromInput, Decimal, Error, Integer, KeyRef, Num, SFVResult, String, StringRef, TokenRef,
 };
+
+#[cfg(feature = "parsed-types")]
+use crate::{Dictionary, Item, List};
 
 use std::borrow::Cow;
 use std::convert::TryFrom;
@@ -115,6 +117,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses input into structured field value of Dictionary type
+    #[cfg(feature = "parsed-types")]
     pub fn parse_dictionary(self) -> SFVResult<Dictionary> {
         let mut dict = Dictionary::new();
         self.parse_dictionary_with_visitor(&mut dict)?;
@@ -122,23 +125,27 @@ impl<'a> Parser<'a> {
     }
 
     /// Like `parse_dictionary`, but uses the given visitor instead of producing a [`Dictionary`].
-    ///
-    /// This can also be used to parse a dictionary that is split into multiple lines by merging
-    /// them into an existing structure:
-    ///
-    /// ```
-    /// # use sfv::{Parser, SerializeValue};
-    /// # fn main() -> Result<(), sfv::Error> {
-    /// let mut dict = Parser::from_str("a=1").parse_dictionary()?;
-    ///
-    /// Parser::from_str("b=2").parse_dictionary_with_visitor(&mut dict)?;
-    ///
-    /// assert_eq!(
-    ///     dict.serialize_value()?,
-    ///     "a=1, b=2",
-    /// );
-    /// # Ok(())
-    /// # }
+    #[cfg_attr(
+        feature = "parsed-types",
+        doc = r##"
+This can also be used to parse a dictionary that is split into multiple lines by merging
+them into an existing structure:
+
+```
+# use sfv::{Parser, SerializeValue};
+# fn main() -> Result<(), sfv::Error> {
+let mut dict = Parser::from_str("a=1").parse_dictionary()?;
+
+Parser::from_str("b=2").parse_dictionary_with_visitor(&mut dict)?;
+
+assert_eq!(
+    dict.serialize_value()?,
+    "a=1, b=2",
+);
+# Ok(())
+# }
+"##
+    )]
     pub fn parse_dictionary_with_visitor(
         self,
         visitor: &mut (impl ?Sized + DictionaryVisitor<'a>),
@@ -147,6 +154,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses input into structured field value of List type
+    #[cfg(feature = "parsed-types")]
     pub fn parse_list(self) -> SFVResult<List> {
         let mut list = List::new();
         self.parse_list_with_visitor(&mut list)?;
@@ -154,24 +162,27 @@ impl<'a> Parser<'a> {
     }
 
     /// Like `parse_list`, but uses the given visitor instead of producing a [`List`].
-    ///
-    /// This can also be used to parse a list that is split into multiple lines by merging them
-    /// into an existing structure:
-    ///
-    /// ```
-    /// # use sfv::{Parser, SerializeValue};
-    /// # fn main() -> Result<(), sfv::Error> {
-    /// let mut list = Parser::from_str("11, (12 13)").parse_list()?;
-    ///
-    /// Parser::from_str(r#""foo",        "bar""#).parse_list_with_visitor(&mut list)?;
-    ///
-    /// assert_eq!(
-    ///     list.serialize_value()?,
-    ///     r#"11, (12 13), "foo", "bar""#,
-    /// );
-    /// # Ok(())
-    /// # }
-    /// ```
+    #[cfg_attr(
+        feature = "parsed-types",
+        doc = r##"
+This can also be used to parse a list that is split into multiple lines by merging them
+into an existing structure:
+```
+# use sfv::{Parser, SerializeValue};
+# fn main() -> Result<(), sfv::Error> {
+let mut list = Parser::from_str("11, (12 13)").parse_list()?;
+
+Parser::from_str(r#""foo",        "bar""#).parse_list_with_visitor(&mut list)?;
+
+assert_eq!(
+    list.serialize_value()?,
+    r#"11, (12 13), "foo", "bar""#,
+);
+# Ok(())
+# }
+```
+"##
+    )]
     pub fn parse_list_with_visitor(
         self,
         visitor: &mut (impl ?Sized + ListVisitor<'a>),
@@ -180,6 +191,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses input into structured field value of Item type
+    #[cfg(feature = "parsed-types")]
     pub fn parse_item(self) -> SFVResult<Item> {
         let mut item = Item::new(false);
         self.parse_item_with_visitor(&mut item)?;

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -1,5 +1,8 @@
 use crate::serializer::Serializer;
-use crate::{Error, Item, KeyRef, ListEntry, RefBareItem, SFVResult};
+use crate::{Error, KeyRef, RefBareItem, SFVResult};
+
+#[cfg(feature = "parsed-types")]
+use crate::{Item, ListEntry};
 
 use std::borrow::BorrowMut;
 
@@ -170,6 +173,7 @@ impl<W: BorrowMut<String>> RefListSerializer<W> {
         }
     }
 
+    #[cfg(feature = "parsed-types")]
     pub fn members<'b>(&mut self, members: impl IntoIterator<Item = &'b ListEntry>) {
         for value in members {
             match value {
@@ -283,6 +287,7 @@ impl<W: BorrowMut<String>> RefDictSerializer<W> {
         }
     }
 
+    #[cfg(feature = "parsed-types")]
     pub fn members<'b>(
         &mut self,
         members: impl IntoIterator<Item = (impl AsRef<KeyRef>, &'b ListEntry)>,
@@ -338,6 +343,7 @@ impl<'a> RefInnerListSerializer<'a> {
         RefParameterSerializer { buffer }
     }
 
+    #[cfg(feature = "parsed-types")]
     pub fn items<'b>(&mut self, items: impl IntoIterator<Item = &'b Item>) {
         for item in items {
             self.bare_item(&item.bare_item).parameters(&item.params);

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,10 +1,12 @@
 use crate::utils;
-use crate::{
-    Decimal, Dictionary, Integer, Item, KeyRef, List, RefBareItem, SFVResult, StringRef, TokenRef,
-};
+use crate::{Decimal, Integer, KeyRef, RefBareItem, StringRef, TokenRef};
 use std::fmt::Write as _;
 
+#[cfg(feature = "parsed-types")]
+use crate::{Dictionary, Item, List, SFVResult};
+
 /// Serializes structured field value into String.
+#[cfg(feature = "parsed-types")]
 pub trait SerializeValue {
     /// Serializes structured field value into String.
     /// # Examples
@@ -23,6 +25,7 @@ pub trait SerializeValue {
     fn serialize_value(&self) -> SFVResult<String>;
 }
 
+#[cfg(feature = "parsed-types")]
 impl SerializeValue for Dictionary {
     fn serialize_value(&self) -> SFVResult<String> {
         let mut ser = crate::RefDictSerializer::new();
@@ -31,6 +34,7 @@ impl SerializeValue for Dictionary {
     }
 }
 
+#[cfg(feature = "parsed-types")]
 impl SerializeValue for List {
     fn serialize_value(&self) -> SFVResult<String> {
         let mut ser = crate::RefListSerializer::new();
@@ -39,6 +43,7 @@ impl SerializeValue for List {
     }
 }
 
+#[cfg(feature = "parsed-types")]
 impl SerializeValue for Item {
     fn serialize_value(&self) -> SFVResult<String> {
         Ok(crate::RefItemSerializer::new()

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -1,34 +1,39 @@
 use crate::serializer::Serializer;
-use crate::SerializeValue;
-use crate::{
-    integer, key_ref, string_ref, token_ref, BareItem, Decimal, Dictionary, Error, InnerList, Item,
-    List, Parameters,
-};
+use crate::{integer, key_ref, string_ref, token_ref, Decimal};
 use std::convert::TryFrom;
 use std::error::Error as StdError;
+
+#[cfg(feature = "parsed-types")]
+use crate::SerializeValue;
+
+#[cfg(feature = "parsed-types")]
+use crate::{BareItem, Dictionary, Error, InnerList, Item, List, Parameters};
+
+#[cfg(feature = "parsed-types")]
 use std::iter::FromIterator;
 
 #[test]
-fn serialize_value_empty_dict() -> Result<(), Box<dyn StdError>> {
+#[cfg(feature = "parsed-types")]
+fn serialize_value_empty_dict() {
     let dict_field_value = Dictionary::new();
     assert_eq!(
         Err(Error::new("serializing empty dictionary is not allowed")),
         dict_field_value.serialize_value()
     );
-    Ok(())
 }
 
 #[test]
-fn serialize_value_empty_list() -> Result<(), Box<dyn StdError>> {
+#[cfg(feature = "parsed-types")]
+fn serialize_value_empty_list() {
     let list_field_value = List::new();
     assert_eq!(
         Err(Error::new("serializing empty list is not allowed")),
         list_field_value.serialize_value()
     );
-    Ok(())
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn StdError>> {
     let item1 = Item::new(Decimal::try_from(42.4568)?);
     let item2_param = Parameters::from_iter(vec![(
@@ -61,6 +66,7 @@ fn serialize_value_list_mixed_members_with_params() -> Result<(), Box<dyn StdErr
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_item_byteseq_with_param() -> Result<(), Box<dyn StdError>> {
     let item_param = (
         key_ref("a").to_owned(),
@@ -73,6 +79,7 @@ fn serialize_item_byteseq_with_param() -> Result<(), Box<dyn StdError>> {
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_item_without_params() -> Result<(), Box<dyn StdError>> {
     let item = Item::new(1);
     assert_eq!("1", item.serialize_value()?);
@@ -80,6 +87,7 @@ fn serialize_item_without_params() -> Result<(), Box<dyn StdError>> {
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_item_with_bool_true_param() -> Result<(), Box<dyn StdError>> {
     let param = Parameters::from_iter(vec![(key_ref("a").to_owned(), BareItem::Boolean(true))]);
     let item = Item::with_params(Decimal::try_from(12.35)?, param);
@@ -88,6 +96,7 @@ fn serialize_item_with_bool_true_param() -> Result<(), Box<dyn StdError>> {
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_item_with_token_param() -> Result<(), Box<dyn StdError>> {
     let param = Parameters::from_iter(vec![(
         key_ref("a1").to_owned(),
@@ -250,6 +259,7 @@ fn serialize_bool() {
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_params_bool() {
     let mut buf = String::new();
     Serializer::serialize_parameter(key_ref("*b"), true, &mut buf);
@@ -261,6 +271,7 @@ fn serialize_params_bool() {
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_params_string() {
     let mut buf = String::new();
 
@@ -269,6 +280,7 @@ fn serialize_params_string() {
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_params_numbers() -> Result<(), Box<dyn StdError>> {
     let mut buf = String::new();
 
@@ -301,6 +313,7 @@ fn serialize_key() {
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_list_of_items_and_inner_list() -> Result<(), Box<dyn StdError>> {
     let item1 = Item::new(12);
     let item2 = Item::new(14);
@@ -321,6 +334,7 @@ fn serialize_list_of_items_and_inner_list() -> Result<(), Box<dyn StdError>> {
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_list_of_lists() -> Result<(), Box<dyn StdError>> {
     let item1 = Item::new(1);
     let item2 = Item::new(2);
@@ -335,6 +349,7 @@ fn serialize_list_of_lists() -> Result<(), Box<dyn StdError>> {
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_list_with_bool_item_and_bool_params() -> Result<(), Box<dyn StdError>> {
     let item1_params = Parameters::from_iter(vec![
         (key_ref("a").to_owned(), BareItem::Boolean(true)),
@@ -349,6 +364,7 @@ fn serialize_list_with_bool_item_and_bool_params() -> Result<(), Box<dyn StdErro
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_dictionary_with_params() -> Result<(), Box<dyn StdError>> {
     let item1_params = Parameters::from_iter(vec![
         (key_ref("a").to_owned(), 1.into()),
@@ -381,6 +397,7 @@ fn serialize_dictionary_with_params() -> Result<(), Box<dyn StdError>> {
 }
 
 #[test]
+#[cfg(feature = "parsed-types")]
 fn serialize_dict_empty_member_value() -> Result<(), Box<dyn StdError>> {
     let inner_list = InnerList::new(vec![]);
     let input = Dictionary::from_iter(vec![(key_ref("a").to_owned(), inner_list.into())]);


### PR DESCRIPTION
For users who only need to parse or serialize using the visitor traits, this eliminates a dependency.