### PR TITLE
Update criterion dev dependency to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ref-cast = "1.0.23"
 [dev-dependencies]
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
-criterion = "0.4.0"
+criterion = "0.5.1"
 base32 = "0.5.1"
 
 [[bench]]


### PR DESCRIPTION
This eliminates a `cargo audit` warning about a transient dependency on the unmaintained `atty` crate.