### PR TITLE
Remove redundant Ref prefix from serializer types

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,8 +3,8 @@ extern crate criterion;
 
 use criterion::{BenchmarkId, Criterion};
 use sfv::{
-    integer, key_ref, string_ref, token_ref, Decimal, Parser, RefDictSerializer, RefItemSerializer,
-    RefListSerializer, SerializeValue,
+    integer, key_ref, string_ref, token_ref, Decimal, DictSerializer, ItemSerializer,
+    ListSerializer, Parser, SerializeValue,
 };
 use std::convert::TryFrom;
 
@@ -105,7 +105,7 @@ fn serializing_ref_item(c: &mut Criterion) {
         &fixture,
         move |bench, &input| {
             bench.iter(|| {
-                let ser = RefItemSerializer::new();
+                let ser = ItemSerializer::new();
                 ser.bare_item(input.as_bytes()).finish()
             });
         },
@@ -115,7 +115,7 @@ fn serializing_ref_item(c: &mut Criterion) {
 fn serializing_ref_list(c: &mut Criterion) {
     c.bench_function("serializing_ref_list", move |bench| {
         bench.iter(|| {
-            let mut ser = RefListSerializer::new();
+            let mut ser = ListSerializer::new();
             ser.bare_item(token_ref("a"));
             ser.bare_item(token_ref("abcdefghigklmnoprst"));
             ser.bare_item(integer(123456785686457));
@@ -139,7 +139,7 @@ fn serializing_ref_list(c: &mut Criterion) {
 fn serializing_ref_dict(c: &mut Criterion) {
     c.bench_function("serializing_ref_dict", move |bench| {
         bench.iter(|| {
-            let mut ser = RefDictSerializer::new();
+            let mut ser = DictSerializer::new();
             ser.bare_item(key_ref("a"), true);
             ser.bare_item(key_ref("dict_key2"), token_ref("abcdefghigklmnoprst"));
             ser.bare_item(key_ref("dict_key3"), integer(123456785686457));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,11 +73,11 @@ match dict.get("u") {
 ### Serialization
 Serializes an `Item`:
 ```
-use sfv::{Decimal, KeyRef, RefItemSerializer, StringRef};
+use sfv::{Decimal, ItemSerializer, KeyRef, StringRef};
 use std::convert::TryFrom;
 
 # fn main() -> Result<(), sfv::Error> {
-let serialized_item = RefItemSerializer::new()
+let serialized_item = ItemSerializer::new()
     .bare_item(StringRef::from_str("foo")?)
     .parameter(KeyRef::from_str("key")?, Decimal::try_from(13.45655)?)
     .finish();
@@ -89,10 +89,10 @@ assert_eq!(serialized_item, r#""foo";key=13.457"#);
 
 Serializes a `List`:
 ```
-use sfv::{KeyRef, RefListSerializer, StringRef, TokenRef};
+use sfv::{KeyRef, ListSerializer, StringRef, TokenRef};
 
 # fn main() -> Result<(), sfv::Error> {
-let mut ser = RefListSerializer::new();
+let mut ser = ListSerializer::new();
 
 ser.bare_item(TokenRef::from_str("tok")?);
 
@@ -118,10 +118,10 @@ assert_eq!(
 
 Serializes a `Dictionary`:
 ```
-use sfv::{KeyRef, RefDictSerializer, StringRef};
+use sfv::{DictSerializer, KeyRef, StringRef};
 
 # fn main() -> Result<(), sfv::Error> {
-let mut ser = RefDictSerializer::new();
+let mut ser = DictSerializer::new();
 
 ser.bare_item(KeyRef::from_str("key1")?, StringRef::from_str("apple")?);
 
@@ -178,8 +178,7 @@ pub use integer::{integer, Integer};
 pub use key::{key_ref, Key, KeyRef};
 pub use parser::Parser;
 pub use ref_serializer::{
-    RefDictSerializer, RefInnerListSerializer, RefItemSerializer, RefListSerializer,
-    RefParameterSerializer,
+    DictSerializer, InnerListSerializer, ItemSerializer, ListSerializer, ParameterSerializer,
 };
 pub use string::{string_ref, String, StringRef};
 pub use token::{token_ref, Token, TokenRef};
@@ -354,7 +353,7 @@ pub type BareItem = GenericBareItem<String, Vec<u8>, Token>;
 
 /// A [bare item] that borrows its data.
 ///
-/// Used to serialize values via [`RefItemSerializer`], [`RefListSerializer`], and [`RefDictSerializer`].
+/// Used to serialize values via [`ItemSerializer`], [`ListSerializer`], and [`DictSerializer`].
 ///
 /// [bare item]: <https://httpwg.org/specs/rfc8941.html#item>
 pub type RefBareItem<'a> = GenericBareItem<&'a StringRef, &'a [u8], &'a TokenRef>;

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -28,7 +28,7 @@ pub trait SerializeValue {
 #[cfg(feature = "parsed-types")]
 impl SerializeValue for Dictionary {
     fn serialize_value(&self) -> SFVResult<String> {
-        let mut ser = crate::RefDictSerializer::new();
+        let mut ser = crate::DictSerializer::new();
         ser.members(self);
         ser.finish()
     }
@@ -37,7 +37,7 @@ impl SerializeValue for Dictionary {
 #[cfg(feature = "parsed-types")]
 impl SerializeValue for List {
     fn serialize_value(&self) -> SFVResult<String> {
-        let mut ser = crate::RefListSerializer::new();
+        let mut ser = crate::ListSerializer::new();
         ser.members(self);
         ser.finish()
     }
@@ -46,7 +46,7 @@ impl SerializeValue for List {
 #[cfg(feature = "parsed-types")]
 impl SerializeValue for Item {
     fn serialize_value(&self) -> SFVResult<String> {
-        Ok(crate::RefItemSerializer::new()
+        Ok(crate::ItemSerializer::new()
             .bare_item(&self.bare_item)
             .parameters(&self.params)
             .finish())


### PR DESCRIPTION
These types can serialize complete strings, so the prefix is meaningless.