### PR TITLE
Replace RFC 8941 with RFC 9651 as crate's default version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 documentation = "https://docs.rs/sfv"
 description = """Structured Field Values for HTTP parser.
-Implementation of RFC 8941."""
+Implementation of RFC 8941 and RFC 9651."""
 repository = "https://github.com/undef1nd/sfv"
 keywords = ["http-header", "structured-header", ]
 exclude = ["tests/**", ".github/*"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Structured Field Values for HTTP
 
-`sfv` crate is an implementation of *Structured Field Values for HTTP* as specified in [RFC 8941](https://httpwg.org/specs/rfc8941.html) for parsing and serializing HTTP field values (also known as "structured headers" or "structured trailers").
+`sfv` is an implementation of *Structured Field Values for HTTP* as specified in [RFC 9651](https://httpwg.org/specs/rfc9651.html) for parsing and serializing HTTP field values (also known as "structured headers" or "structured trailers").
 
 It also exposes a set of types that might be useful for defining new structured fields.
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
+arbitrary = { version = "1.4.1", features = ["derive"] }
 libfuzzer-sys = "0.4"
 
 [dependencies.sfv]

--- a/fuzz/fuzz_targets/input.rs
+++ b/fuzz/fuzz_targets/input.rs
@@ -1,0 +1,5 @@
+#[derive(arbitrary::Arbitrary, Debug)]
+pub struct Input<'a> {
+    pub data: &'a [u8],
+    pub version: sfv::Version,
+}

--- a/fuzz/fuzz_targets/parse_dictionary.rs
+++ b/fuzz/fuzz_targets/parse_dictionary.rs
@@ -1,7 +1,11 @@
 #![no_main]
 
+mod input;
+
 use libfuzzer_sys::fuzz_target;
 
-fuzz_target!(|data: &[u8]| {
-    let _ = sfv::Parser::new(data).parse_dictionary();
+fuzz_target!(|input: input::Input| {
+    let _ = sfv::Parser::new(input.data)
+        .with_version(input.version)
+        .parse_dictionary();
 });

--- a/fuzz/fuzz_targets/parse_item.rs
+++ b/fuzz/fuzz_targets/parse_item.rs
@@ -1,7 +1,11 @@
 #![no_main]
 
+mod input;
+
 use libfuzzer_sys::fuzz_target;
 
-fuzz_target!(|data: &[u8]| {
-    let _ = sfv::Parser::new(data).parse_item();
+fuzz_target!(|input: input::Input| {
+    let _ = sfv::Parser::new(input.data)
+        .with_version(input.version)
+        .parse_item();
 });

--- a/fuzz/fuzz_targets/parse_list.rs
+++ b/fuzz/fuzz_targets/parse_list.rs
@@ -1,7 +1,11 @@
 #![no_main]
 
+mod input;
+
 use libfuzzer_sys::fuzz_target;
 
-fuzz_target!(|data: &[u8]| {
-    let _ = sfv::Parser::new(data).parse_list();
+fuzz_target!(|input: input::Input| {
+    let _ = sfv::Parser::new(input.data)
+        .with_version(input.version)
+        .parse_list();
 });

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,0 +1,44 @@
+use crate::Integer;
+
+use std::fmt;
+
+/// A structured field value [date].
+///
+/// Dates represent an integer number of seconds from the Unix epoch.
+///
+/// [`Version::Rfc9651`][`crate::Version::Rfc9651`] supports bare items of this
+/// type; [`Version::Rfc8941`][`crate::Version::Rfc8941`] does not.
+///
+/// [date]: <https://httpwg.org/specs/rfc9651.html#date>
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct Date(Integer);
+
+impl Date {
+    /// The minimum value for a parsed or serialized date, corresponding to
+    /// [`Integer::MIN`] seconds from the Unix epoch.
+    pub const MIN: Self = Self::from_unix_seconds(Integer::MIN);
+
+    /// The maximum value for a parsed or serialized date, corresponding to
+    /// [`Integer::MAX`] seconds from the Unix epoch.
+    pub const MAX: Self = Self::from_unix_seconds(Integer::MAX);
+
+    /// The Unix epoch: `1970-01-01T00:00:00Z`.
+    pub const UNIX_EPOCH: Self = Self::from_unix_seconds(Integer::ZERO);
+
+    /// Returns the date as an integer number of seconds from the Unix epoch.
+    pub fn unix_seconds(&self) -> Integer {
+        self.0
+    }
+
+    /// Creates a date from an integer number of seconds from the Unix epoch.
+    pub const fn from_unix_seconds(v: Integer) -> Self {
+        Self(v)
+    }
+}
+
+impl fmt::Display for Date {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "@{}", self.unix_seconds())
+    }
+}

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -7,7 +7,7 @@ use std::fmt;
 ///
 /// Decimals have 12 digits of integer precision and 3 digits of fractional precision.
 ///
-/// [decimal]: <https://httpwg.org/specs/rfc8941.html#decimal>
+/// [decimal]: <https://httpwg.org/specs/rfc9651.html#decimal>
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Decimal(Integer);

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -7,7 +7,7 @@ const RANGE_I64: std::ops::RangeInclusive<i64> = -999_999_999_999_999..=999_999_
 
 /// A structured field value [integer].
 ///
-/// [integer]: <https://httpwg.org/specs/rfc8941.html#integer>
+/// [integer]: <https://httpwg.org/specs/rfc9651.html#integer>
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Integer(
@@ -66,7 +66,7 @@ macro_rules! impl_conversion {
                 Integer(v.into())
             }
         }
-        impl<S, B, T> From<$t> for GenericBareItem<S, B, T> {
+        impl<S, B, T, D> From<$t> for GenericBareItem<S, B, T, D> {
             fn from(v: $t) -> Self {
                 Self::Integer(v.into())
             }
@@ -83,7 +83,7 @@ macro_rules! impl_conversion {
                 }
             }
         }
-        impl<S, B, T> TryFrom<$t> for GenericBareItem<S, B, T> {
+        impl<S, B, T, D> TryFrom<$t> for GenericBareItem<S, B, T, D> {
             type Error = Error;
 
             fn try_from(v: $t) -> Result<Self, Error> {

--- a/src/key.rs
+++ b/src/key.rs
@@ -13,7 +13,7 @@ use std::fmt;
 /// ^[A-Za-z*][A-Za-z*0-9!#$%&'+\-.^_`|~]*$
 /// ```
 ///
-/// [key]: <https://httpwg.org/specs/rfc8941.html#key>
+/// [key]: <https://httpwg.org/specs/rfc9651.html#key>
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Key(String);
 
@@ -27,7 +27,7 @@ pub struct Key(String);
 ///
 /// This type is to [`Key`] as [`str`] is to [`String`].
 ///
-/// [key]: <https://httpwg.org/specs/rfc8941.html#key>
+/// [key]: <https://httpwg.org/specs/rfc9651.html#key>
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, ref_cast::RefCastCustom)]
 #[repr(transparent)]
 pub struct KeyRef(str);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,6 +584,7 @@ where
 ///
 /// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html#using-new-structured-types-in-extensions>
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Version {
     /// [RFC 8941], which does not support dates or display strings.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 /*!
-`sfv` is an implementation of *Structured Field Values for HTTP*, as specified in [RFC 8941](https://httpwg.org/specs/rfc8941.html) for parsing and serializing HTTP field values.
+`sfv` is an implementation of *Structured Field Values for HTTP*, as specified in [RFC 9651](https://httpwg.org/specs/rfc9651.html) for parsing and serializing HTTP field values.
 It also exposes a set of types that might be useful for defining new structured fields.
 
 # Data Structures
 
 There are three types of structured fields:
 
-- `Item` -- an `Integer`, `Decimal`, `String`, `Token`, `Byte Sequence`, or `Boolean`. It can have associated `Parameters`.
+- `Item` -- an `Integer`, `Decimal`, `String`, `Token`, `Byte Sequence`, `Boolean`, `Date`, or `Display String`. It can have associated `Parameters`.
 - `List` -- an array of zero or more members, each of which can be an `Item` or an `InnerList`, both of which can have `Parameters`.
 - `Dictionary` -- an ordered map of name-value pairs, where the names are short textual strings and the values are `Item`s or arrays of `Items` (represented with `InnerList`), both of which can have associated parameters. There can be zero or more members, and their names are unique in the scope of the `Dictionary` they occur within.
 
@@ -60,6 +60,8 @@ match dict.get("u") {
         BareItem::Decimal(val) => { /* ... */ }
         BareItem::String(val) => { /* ... */ }
         BareItem::ByteSeq(val) => { /* ... */ }
+        BareItem::Date(val) => { /* ... */ }
+        BareItem::DisplayString(val) => { /* ... */ }
     },
     Some(ListEntry::InnerList(inner_list)) => { /* ... */ }
     None => { /* ... */ }
@@ -155,6 +157,7 @@ assert_eq!(
 
 #![deny(missing_docs)]
 
+mod date;
 mod decimal;
 mod error;
 mod integer;
@@ -186,7 +189,10 @@ mod test_token;
 
 use std::borrow::{Borrow, Cow};
 use std::convert::TryFrom;
+use std::fmt;
+use std::string::String as StdString;
 
+pub use date::Date;
 pub use decimal::Decimal;
 pub use error::Error;
 pub use integer::{integer, Integer};
@@ -213,36 +219,56 @@ type SFVResult<T> = std::result::Result<T, Error>;
 /// - [`RefBareItem`], for completely borrowed data
 /// - [`BareItemFromInput`], for data borrowed from input when possible
 ///
-/// [bare item]: <https://httpwg.org/specs/rfc8941.html#item>
+/// [bare item]: <https://httpwg.org/specs/9651.html#item>
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub enum GenericBareItem<S, B, T> {
-    /// A [decimal](https://httpwg.org/specs/rfc8941.html#decimal).
+pub enum GenericBareItem<S, B, T, D> {
+    /// A [decimal](https://httpwg.org/specs/rfc9651.html#decimal).
     // sf-decimal  = ["-"] 1*12DIGIT "." 1*3DIGIT
     Decimal(Decimal),
-    /// An [integer](https://httpwg.org/specs/rfc8941.html#integer).
+    /// An [integer](https://httpwg.org/specs/rfc9651.html#integer).
     // sf-integer = ["-"] 1*15DIGIT
     Integer(Integer),
-    /// A [string](https://httpwg.org/specs/rfc8941.html#string).
+    /// A [string](https://httpwg.org/specs/rfc9651.html#string).
     // sf-string = DQUOTE *chr DQUOTE
     // chr       = unescaped / escaped
     // unescaped = %x20-21 / %x23-5B / %x5D-7E
     // escaped   = "\" ( DQUOTE / "\" )
     String(S),
-    /// A [byte sequence](https://httpwg.org/specs/rfc8941.html#binary).
+    /// A [byte sequence](https://httpwg.org/specs/rfc9651.html#binary).
     // ":" *(base64) ":"
     // base64    = ALPHA / DIGIT / "+" / "/" / "="
     ByteSeq(B),
-    /// A [boolean](https://httpwg.org/specs/rfc8941.html#boolean).
+    /// A [boolean](https://httpwg.org/specs/rfc9651.html#boolean).
     // sf-boolean = "?" boolean
     // boolean    = "0" / "1"
     Boolean(bool),
-    /// A [token](https://httpwg.org/specs/rfc8941.html#token).
+    /// A [token](https://httpwg.org/specs/rfc9651.html#token).
     // sf-token = ( ALPHA / "*" ) *( tchar / ":" / "/" )
     Token(T),
+    /// A [date](https://httpwg.org/specs/rfc9651.html#date).
+    ///
+    /// [`Parser`] will never produce this variant when used with
+    /// [`Version::Rfc8941`].
+    // sf-date = "@" sf-integer
+    Date(Date),
+    /// A [display string](https://httpwg.org/specs/rfc9651.html#displaystring).
+    ///
+    /// Display Strings are similar to [`String`]s, in that they consist of zero
+    /// or more characters, but they allow Unicode scalar values (i.e., all
+    /// Unicode code points except for surrogates), unlike [`String`]s.
+    ///
+    /// [`Parser`] will never produce this variant when used with
+    /// [`Version::Rfc8941`].
+    ///
+    /// [display string]: <https://httpwg.org/specs/rfc9651.html#displaystring>
+    // sf-displaystring = "%" DQUOTE *( unescaped / "\" / pct-encoded ) DQUOTE
+    // pct-encoded      = "%" lc-hexdig lc-hexdig
+    // lc-hexdig        = DIGIT / %x61-66 ; 0-9, a-f
+    DisplayString(D),
 }
 
-impl<S, B, T> GenericBareItem<S, B, T> {
+impl<S, B, T, D> GenericBareItem<S, B, T, D> {
     /// If the bare item is a decimal, returns it; otherwise returns `None`.
     pub fn as_decimal(&self) -> Option<Decimal> {
         match *self {
@@ -290,27 +316,49 @@ impl<S, B, T> GenericBareItem<S, B, T> {
             _ => None,
         }
     }
+
+    /// If the bare item is a date, returns it; otherwise returns `None`.
+    pub fn as_date(&self) -> Option<Date> {
+        match *self {
+            Self::Date(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    /// If the bare item is a display string, returns a reference to it; otherwise returns `None`.
+    pub fn as_display_string(&self) -> Option<&D> {
+        match *self {
+            Self::DisplayString(ref val) => Some(val),
+            _ => None,
+        }
+    }
 }
 
-impl<S, B, T> From<Integer> for GenericBareItem<S, B, T> {
+impl<S, B, T, D> From<Integer> for GenericBareItem<S, B, T, D> {
     fn from(val: Integer) -> Self {
         Self::Integer(val)
     }
 }
 
-impl<S, B, T> From<bool> for GenericBareItem<S, B, T> {
+impl<S, B, T, D> From<bool> for GenericBareItem<S, B, T, D> {
     fn from(val: bool) -> Self {
         Self::Boolean(val)
     }
 }
 
-impl<S, B, T> From<Decimal> for GenericBareItem<S, B, T> {
+impl<S, B, T, D> From<Decimal> for GenericBareItem<S, B, T, D> {
     fn from(val: Decimal) -> Self {
         Self::Decimal(val)
     }
 }
 
-impl<S, B, T> TryFrom<f32> for GenericBareItem<S, B, T> {
+impl<S, B, T, D> From<Date> for GenericBareItem<S, B, T, D> {
+    fn from(val: Date) -> Self {
+        Self::Date(val)
+    }
+}
+
+impl<S, B, T, D> TryFrom<f32> for GenericBareItem<S, B, T, D> {
     type Error = Error;
 
     fn try_from(val: f32) -> Result<Self, Error> {
@@ -318,7 +366,7 @@ impl<S, B, T> TryFrom<f32> for GenericBareItem<S, B, T> {
     }
 }
 
-impl<S, B, T> TryFrom<f64> for GenericBareItem<S, B, T> {
+impl<S, B, T, D> TryFrom<f64> for GenericBareItem<S, B, T, D> {
     type Error = Error;
 
     fn try_from(val: f64) -> Result<Self, Error> {
@@ -326,7 +374,7 @@ impl<S, B, T> TryFrom<f64> for GenericBareItem<S, B, T> {
     }
 }
 
-impl<S, T> From<Vec<u8>> for GenericBareItem<S, Vec<u8>, T> {
+impl<S, T, D> From<Vec<u8>> for GenericBareItem<S, Vec<u8>, T, D> {
     fn from(val: Vec<u8>) -> Self {
         Self::ByteSeq(val)
     }
@@ -370,34 +418,86 @@ pub(crate) enum Num {
 
 /// A [bare item] that owns its data.
 ///
-/// [bare item]: <https://httpwg.org/specs/rfc8941.html#item>
+/// [bare item]: <https://httpwg.org/specs/rfc9651.html#item>
 #[cfg_attr(
     feature = "parsed-types",
     doc = "Used to construct an [`Item`] or [`Parameters`] values."
 )]
-pub type BareItem = GenericBareItem<String, Vec<u8>, Token>;
+///
+/// Note: This type deliberately does not implement `From<StdString>` as a
+/// shorthand for [`BareItem::DisplayString`] because it is too easy to confuse
+/// with conversions from [`String`]:
+///
+/// ```compile_fail
+/// # use sfv::BareItem;
+/// let _: BareItem = "x".to_owned().into();
+/// ```
+///
+/// Instead, use:
+///
+/// ```
+/// # use sfv::BareItem;
+/// let _ = BareItem::DisplayString("x".to_owned());
+/// ```
+pub type BareItem = GenericBareItem<String, Vec<u8>, Token, StdString>;
 
 /// A [bare item] that borrows its data.
 ///
 /// Used to serialize values via [`ItemSerializer`], [`ListSerializer`], and [`DictSerializer`].
 ///
-/// [bare item]: <https://httpwg.org/specs/rfc8941.html#item>
-pub type RefBareItem<'a> = GenericBareItem<&'a StringRef, &'a [u8], &'a TokenRef>;
+/// [bare item]: <https://httpwg.org/specs/rfc9651.html#item>
+///
+/// Note: This type deliberately does not implement `From<&str>` as a shorthand
+/// for [`RefBareItem::DisplayString`] because it is too easy to confuse with
+/// conversions from [`StringRef`]:
+///
+/// ```compile_fail
+/// # use sfv::RefBareItem;
+/// let _: RefBareItem = "x".into();
+/// ```
+///
+/// Instead, use:
+///
+/// ```
+/// # use sfv::RefBareItem;
+/// let _ = RefBareItem::DisplayString("x");
+/// ```
+pub type RefBareItem<'a> = GenericBareItem<&'a StringRef, &'a [u8], &'a TokenRef, &'a str>;
 
 /// A [bare item] that borrows data from input when possible.
 ///
 /// Used to parse input incrementally in the [`visitor`] module.
 ///
-/// [bare item]: <https://httpwg.org/specs/rfc8941.html#item>
-pub type BareItemFromInput<'a> = GenericBareItem<Cow<'a, StringRef>, Vec<u8>, &'a TokenRef>;
+/// [bare item]: <https://httpwg.org/specs/rfc9651.html#item>
+///
+/// Note: This type deliberately does not implement `From<Cow<str>>` as a
+/// shorthand for [`BareItemFromInput::DisplayString`] because it is too easy to
+/// confuse with conversions from [`Cow<StringRef>`]:
+///
+/// ```compile_fail
+/// # use sfv::BareItemFromInput;
+/// # use std::borrow::Cow;
+/// let _: BareItemFromInput = "x".to_owned().into();
+/// ```
+///
+/// Instead, use:
+///
+/// ```
+/// # use sfv::BareItemFromInput;
+/// # use std::borrow::Cow;
+/// let _ = BareItemFromInput::DisplayString(Cow::Borrowed("x"));
+/// ```
+pub type BareItemFromInput<'a> =
+    GenericBareItem<Cow<'a, StringRef>, Vec<u8>, &'a TokenRef, Cow<'a, str>>;
 
-impl<'a, S, B, T> From<&'a GenericBareItem<S, B, T>> for RefBareItem<'a>
+impl<'a, S, B, T, D> From<&'a GenericBareItem<S, B, T, D>> for RefBareItem<'a>
 where
     S: Borrow<StringRef>,
     B: Borrow<[u8]>,
     T: Borrow<TokenRef>,
+    D: Borrow<str>,
 {
-    fn from(val: &'a GenericBareItem<S, B, T>) -> RefBareItem<'a> {
+    fn from(val: &'a GenericBareItem<S, B, T, D>) -> RefBareItem<'a> {
         match val {
             GenericBareItem::Integer(val) => RefBareItem::Integer(*val),
             GenericBareItem::Decimal(val) => RefBareItem::Decimal(*val),
@@ -405,6 +505,8 @@ where
             GenericBareItem::ByteSeq(val) => RefBareItem::ByteSeq(val.borrow()),
             GenericBareItem::Boolean(val) => RefBareItem::Boolean(*val),
             GenericBareItem::Token(val) => RefBareItem::Token(val.borrow()),
+            GenericBareItem::Date(val) => RefBareItem::Date(*val),
+            GenericBareItem::DisplayString(val) => RefBareItem::DisplayString(val.borrow()),
         }
     }
 }
@@ -418,6 +520,8 @@ impl<'a> From<BareItemFromInput<'a>> for BareItem {
             BareItemFromInput::ByteSeq(val) => BareItem::ByteSeq(val),
             BareItemFromInput::Boolean(val) => BareItem::Boolean(val),
             BareItemFromInput::Token(val) => BareItem::Token(val.to_owned()),
+            BareItemFromInput::Date(val) => BareItem::Date(val),
+            BareItemFromInput::DisplayString(val) => BareItem::DisplayString(val.into_owned()),
         }
     }
 }
@@ -428,13 +532,13 @@ impl<'a> From<&'a [u8]> for RefBareItem<'a> {
     }
 }
 
-impl<'a, S, B> From<&'a Token> for GenericBareItem<S, B, &'a TokenRef> {
+impl<'a, S, B, D> From<&'a Token> for GenericBareItem<S, B, &'a TokenRef, D> {
     fn from(val: &'a Token) -> Self {
         Self::Token(val)
     }
 }
 
-impl<'a, S, B> From<&'a TokenRef> for GenericBareItem<S, B, &'a TokenRef> {
+impl<'a, S, B, D> From<&'a TokenRef> for GenericBareItem<S, B, &'a TokenRef, D> {
     fn from(val: &'a TokenRef) -> Self {
         Self::Token(val)
     }
@@ -452,12 +556,13 @@ impl<'a> From<&'a StringRef> for RefBareItem<'a> {
     }
 }
 
-impl<S1, B1, T1, S2, B2, T2> PartialEq<GenericBareItem<S2, B2, T2>> for GenericBareItem<S1, B1, T1>
+impl<S1, B1, T1, D1, S2, B2, T2, D2> PartialEq<GenericBareItem<S2, B2, T2, D2>>
+    for GenericBareItem<S1, B1, T1, D1>
 where
     for<'a> RefBareItem<'a>: From<&'a Self>,
-    for<'a> RefBareItem<'a>: From<&'a GenericBareItem<S2, B2, T2>>,
+    for<'a> RefBareItem<'a>: From<&'a GenericBareItem<S2, B2, T2, D2>>,
 {
-    fn eq(&self, other: &GenericBareItem<S2, B2, T2>) -> bool {
+    fn eq(&self, other: &GenericBareItem<S2, B2, T2, D2>) -> bool {
         match (RefBareItem::from(self), RefBareItem::from(other)) {
             (RefBareItem::Integer(a), RefBareItem::Integer(b)) => a == b,
             (RefBareItem::Decimal(a), RefBareItem::Decimal(b)) => a == b,
@@ -465,7 +570,36 @@ where
             (RefBareItem::ByteSeq(a), RefBareItem::ByteSeq(b)) => a == b,
             (RefBareItem::Boolean(a), RefBareItem::Boolean(b)) => a == b,
             (RefBareItem::Token(a), RefBareItem::Token(b)) => a == b,
+            (RefBareItem::Date(a), RefBareItem::Date(b)) => a == b,
+            (RefBareItem::DisplayString(a), RefBareItem::DisplayString(b)) => a == b,
             _ => false,
         }
+    }
+}
+
+/// A version for serialized structured field values.
+///
+/// Each HTTP specification that uses structured field values must indicate
+/// which version it uses. See [the guidance from RFC 9651] for details.
+///
+/// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html#using-new-structured-types-in-extensions>
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Version {
+    /// [RFC 8941], which does not support dates or display strings.
+    ///
+    /// [RFC 8941]: <https://httpwg.org/specs/rfc8941.html>
+    Rfc8941,
+    /// [RFC 9651], which supports dates and display strings.
+    ///
+    /// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html>
+    Rfc9651,
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            Self::Rfc8941 => "RFC 8941",
+            Self::Rfc9651 => "RFC 9651",
+        })
     }
 }

--- a/src/parsed.rs
+++ b/src/parsed.rs
@@ -7,7 +7,7 @@ use std::convert::Infallible;
 ///
 /// Can be used as a member of `List` or `Dictionary`.
 ///
-/// [item]: <https://httpwg.org/specs/rfc8941.html#item>
+/// [item]: <https://httpwg.org/specs/rfc9651.html#item>
 // sf-item   = bare-item parameters
 // bare-item = sf-integer / sf-decimal / sf-string / sf-token
 //             / sf-binary / sf-boolean
@@ -40,7 +40,7 @@ impl Item {
 
 /// A [dictionary]-type structured field value.
 ///
-/// [dictionary]: <https://httpwg.org/specs/rfc8941.html#dictionary>
+/// [dictionary]: <https://httpwg.org/specs/rfc9651.html#dictionary>
 // sf-dictionary  = dict-member *( OWS "," OWS dict-member )
 // dict-member    = member-name [ "=" member-value ]
 // member-name    = key
@@ -49,14 +49,14 @@ pub type Dictionary = IndexMap<Key, ListEntry>;
 
 /// A [list]-type structured field value.
 ///
-/// [list]: <https://httpwg.org/specs/rfc8941.html#list>
+/// [list]: <https://httpwg.org/specs/rfc9651.html#list>
 // sf-list       = list-member *( OWS "," OWS list-member )
 // list-member   = sf-item / inner-list
 pub type List = Vec<ListEntry>;
 
 /// [Parameters] of an [`Item`] or [`InnerList`].
 ///
-/// [parameters]: <https://httpwg.org/specs/rfc8941.html#param>
+/// [parameters]: <https://httpwg.org/specs/rfc9651.html#param>
 // parameters    = *( ";" *SP parameter )
 // parameter     = param-name [ "=" param-value ]
 // param-name    = key
@@ -90,7 +90,7 @@ impl From<InnerList> for ListEntry {
 
 /// An [array] of [`Item`]s with associated [`Parameters`].
 ///
-/// [array]: <https://httpwg.org/specs/rfc8941.html#inner-list>
+/// [array]: <https://httpwg.org/specs/rfc9651.html#inner-list>
 // inner-list    = "(" *SP [ sf-item *( 1*SP sf-item ) *SP ] ")"
 //                 parameters
 #[derive(Debug, Default, PartialEq, Clone)]

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -7,6 +7,15 @@ use crate::{Item, ListEntry};
 use std::borrow::BorrowMut;
 
 /// Serializes `Item` field value components incrementally.
+///
+/// Note: The serialization conforms to [RFC 9651], meaning that
+/// [`Dates`][crate::Date] and [`Display Strings`][RefBareItem::DisplayString],
+/// which cause parsing errors under [RFC 8941], will be serialized
+/// unconditionally. The consumer of this API is responsible for determining
+/// whether it is valid to serialize these bare items for any specific header.
+///
+/// [RFC 8941]: <https://httpwg.org/specs/rfc8941.html>
+/// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html>
 /// ```
 /// use sfv::{KeyRef, ItemSerializer};
 ///
@@ -20,7 +29,7 @@ use std::borrow::BorrowMut;
 /// # Ok(())
 /// # }
 /// ```
-// https://httpwg.org/specs/rfc8941.html#ser-item
+// https://httpwg.org/specs/rfc9651.html#ser-item
 #[derive(Debug)]
 pub struct ItemSerializer<W> {
     buffer: W,
@@ -107,6 +116,14 @@ fn maybe_write_separator(buffer: &mut String, first: &mut bool) {
 
 /// Serializes `List` field value components incrementally.
 ///
+/// Note: The serialization conforms to [RFC 9651], meaning that
+/// [`Dates`][crate::Date] and [`Display Strings`][RefBareItem::DisplayString],
+/// which cause parsing errors under [RFC 8941], will be serialized
+/// unconditionally. The consumer of this API is responsible for determining
+/// whether it is valid to serialize these bare items for any specific header.
+///
+/// [RFC 8941]: <https://httpwg.org/specs/rfc8941.html>
+/// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html>
 /// ```
 /// use sfv::{KeyRef, StringRef, TokenRef, ListSerializer};
 ///
@@ -135,7 +152,7 @@ fn maybe_write_separator(buffer: &mut String, first: &mut bool) {
 /// # Ok(())
 /// # }
 /// ```
-// https://httpwg.org/specs/rfc8941.html#ser-list
+// https://httpwg.org/specs/rfc9651.html#ser-list
 #[derive(Debug)]
 pub struct ListSerializer<W> {
     buffer: W,
@@ -214,7 +231,7 @@ impl<W: BorrowMut<String>> ListSerializer<W> {
     ///
     /// This can only fail if no members were serialized, as [empty lists are
     /// not meant to be serialized at
-    /// all](https://httpwg.org/specs/rfc8941.html#text-serialize).
+    /// all](https://httpwg.org/specs/rfc9651.html#text-serialize).
     pub fn finish(self) -> SFVResult<W> {
         if self.first {
             return Err(Error::new("serializing empty list is not allowed"));
@@ -224,6 +241,16 @@ impl<W: BorrowMut<String>> ListSerializer<W> {
 }
 
 /// Serializes `Dictionary` field value components incrementally.
+///
+/// Note: The serialization conforms to [RFC 9651], meaning that
+/// [`Dates`][crate::Date] and [`Display Strings`][RefBareItem::DisplayString],
+/// which cause parsing errors under [RFC 8941], will be serialized
+/// unconditionally. The consumer of this API is responsible for determining
+/// whether it is valid to serialize these bare items for any specific header.
+///
+/// [RFC 8941]: <https://httpwg.org/specs/rfc8941.html>
+/// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html>
+///
 /// ```
 /// use sfv::{KeyRef, StringRef, TokenRef, DictSerializer, Decimal};
 /// use std::convert::TryFrom;
@@ -255,7 +282,7 @@ impl<W: BorrowMut<String>> ListSerializer<W> {
 /// # Ok(())
 /// # }
 /// ```
-// https://httpwg.org/specs/rfc8941.html#ser-dictionary
+// https://httpwg.org/specs/rfc9651.html#ser-dictionary
 #[derive(Debug)]
 pub struct DictSerializer<W> {
     buffer: W,
@@ -346,7 +373,7 @@ impl<W: BorrowMut<String>> DictSerializer<W> {
     ///
     /// This can only fail if no members were serialized, as [empty dictionaries
     /// are not meant to be serialized at
-    /// all](https://httpwg.org/specs/rfc8941.html#text-serialize).
+    /// all](https://httpwg.org/specs/rfc9651.html#text-serialize).
     pub fn finish(self) -> SFVResult<W> {
         if self.first {
             return Err(Error::new("serializing empty dictionary is not allowed"));
@@ -362,7 +389,7 @@ impl<W: BorrowMut<String>> DictSerializer<W> {
 ///
 /// Failing to drop the serializer or call its `finish` method will result in
 /// an invalid serialization that lacks a closing `)` character.
-// https://httpwg.org/specs/rfc8941.html#ser-innerlist
+// https://httpwg.org/specs/rfc9651.html#ser-innerlist
 #[derive(Debug)]
 pub struct InnerListSerializer<'a> {
     buffer: Option<&'a mut String>,

--- a/src/string.rs
+++ b/src/string.rs
@@ -10,7 +10,7 @@ use std::string::String as StdString;
 /// Strings may only contain printable ASCII characters (i.e. the range
 /// `0x20 ..= 0x7e`).
 ///
-/// [string]: <https://httpwg.org/specs/rfc8941.html#string>
+/// [string]: <https://httpwg.org/specs/rfc9651.html#string>
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct String(StdString);
 
@@ -21,7 +21,7 @@ pub struct String(StdString);
 ///
 /// This type is to [`String`] as [`str`] is to [`std::string::String`].
 ///
-/// [string]: <https://httpwg.org/specs/rfc8941.html#string>
+/// [string]: <https://httpwg.org/specs/rfc9651.html#string>
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, ref_cast::RefCastCustom)]
 #[repr(transparent)]
 pub struct StringRef(str);

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -3,7 +3,7 @@ use crate::{integer, key_ref, string_ref, token_ref, Decimal, Error, Num, Parser
 use std::convert::TryFrom;
 
 #[cfg(feature = "parsed-types")]
-use crate::{BareItem, Dictionary, InnerList, Item, List, Parameters};
+use crate::{BareItem, Date, Dictionary, InnerList, Item, List, Parameters, Version};
 
 #[cfg(feature = "parsed-types")]
 use std::iter::FromIterator;
@@ -855,5 +855,43 @@ fn parse_more_errors() -> Result<(), Error> {
     assert!(Parser::new("(a, 2)")
         .parse_list_with_visitor(&mut parsed_list_header)
         .is_err());
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "parsed-types")]
+fn parse_date() -> Result<(), Error> {
+    let input = "@0";
+
+    assert!(Parser::new(input)
+        .with_version(Version::Rfc8941)
+        .parse_item()
+        .is_err());
+
+    assert_eq!(
+        Parser::new(input).parse_item()?,
+        Item::new(Date::UNIX_EPOCH)
+    );
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "parsed-types")]
+fn parse_display_string() -> Result<(), Error> {
+    let input = r#"%"This is intended for display to %c3%bcsers.""#;
+
+    assert!(Parser::new(input)
+        .with_version(Version::Rfc8941)
+        .parse_item()
+        .is_err());
+
+    assert_eq!(
+        Parser::new(input).parse_item()?,
+        Item::new(BareItem::DisplayString(
+            "This is intended for display to üsers.".to_owned()
+        ))
+    );
+
     Ok(())
 }

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -1,5 +1,5 @@
 use crate::serializer::Serializer;
-use crate::{integer, key_ref, string_ref, token_ref, Decimal, Error};
+use crate::{integer, key_ref, string_ref, token_ref, Date, Decimal, Error};
 use std::convert::TryFrom;
 
 #[cfg(feature = "parsed-types")]
@@ -399,4 +399,18 @@ fn serialize_dict_empty_member_value() -> Result<(), Error> {
     let input = Dictionary::from_iter(vec![(key_ref("a").to_owned(), inner_list.into())]);
     assert_eq!("a=()", input.serialize_value()?);
     Ok(())
+}
+
+#[test]
+fn serialize_date_with() {
+    let mut buf = String::new();
+    Serializer::serialize_date(Date::UNIX_EPOCH, &mut buf);
+    assert_eq!(buf, "@0");
+}
+
+#[test]
+fn serialize_display_string() {
+    let mut buf = String::new();
+    Serializer::serialize_display_string("üsers", &mut buf);
+    assert_eq!(buf, r#"%"%c3%bcsers""#);
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -13,7 +13,7 @@ use std::fmt;
 /// ^[A-Za-z*][A-Za-z*0-9!#$%&'+\-.^_`|~]*$
 /// ```
 ///
-/// [token]: <https://httpwg.org/specs/rfc8941.html#token>
+/// [token]: <https://httpwg.org/specs/rfc9651.html#token>
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Token(String);
 
@@ -27,7 +27,7 @@ pub struct Token(String);
 ///
 /// This type is to [`Token`] as [`str`] is to [`String`].
 ///
-/// [token]: <https://httpwg.org/specs/rfc8941.html#token>
+/// [token]: <https://httpwg.org/specs/rfc9651.html#token>
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, ref_cast::RefCastCustom)]
 #[repr(transparent)]
 pub struct TokenRef(str);

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -66,13 +66,13 @@ pub trait ParameterVisitor<'a> {
     ///
     /// Parsing will be terminated early if an error is returned.
     ///
-    /// Note: Per [RFC 8941], when duplicate parameter keys are encountered in
+    /// Note: Per [RFC 9651], when duplicate parameter keys are encountered in
     /// the same scope, all but the last instance are ignored. Implementations
     /// of this trait must respect that requirement in order to comply with the
     /// specification. For example, if parameters are stored in a map, earlier
     /// values for a given parameter key must be overwritten by later ones.
     ///
-    /// [RFC 8941]: <https://httpwg.org/specs/rfc8941.html#parse-param>
+    /// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html#parse-param>
     fn parameter(
         &mut self,
         key: &'a KeyRef,
@@ -163,14 +163,14 @@ pub trait DictionaryVisitor<'a> {
     ///
     /// Parsing will be terminated early if an error is returned.
     ///
-    /// Note: Per [RFC 8941], when duplicate dictionary keys are encountered in
+    /// Note: Per [RFC 9651], when duplicate dictionary keys are encountered in
     /// the same scope, all but the last instance are ignored. Implementations
     /// of this trait must respect that requirement in order to comply with the
     /// specification. For example, if dictionary entries are stored in a map,
     /// earlier values for a given dictionary key must be overwritten by later
     /// ones.
     ///
-    /// [RFC 8941]: <https://httpwg.org/specs/rfc8941.html#parse-dictionary>
+    /// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html#parse-dictionary>
     fn entry(&mut self, key: &'a KeyRef) -> Result<impl EntryVisitor<'a>, Self::Error>;
 }
 


### PR DESCRIPTION
1. `GenericBareItem` has two additional variants: `Date` and `DisplayString`.
2. Parsing accepts a `Version` enum that controls whether dates and display strings are permitted. The newer RFC 9651 is the default.
3. Parsing always propagates errors based on the version.
4. Serialization always operates under RFC 9651. It is the API consumer's responsibility to avoid serialization of `Date` and `DisplayString` when using RFC 8941.

Fixes #119