### PR TITLE
Do not enable indexmap dependency unless something else enables it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ required-features = ["parsed-types"]
 
 [features]
 default = ["parsed-types"]
-arbitrary = ["dep:arbitrary", "indexmap/arbitrary"]
+arbitrary = ["dep:arbitrary", "indexmap?/arbitrary"]
 parsed-types = ["dep:indexmap"]
 
 [[test]]


### PR DESCRIPTION
Without this change, specifying `--no-default-features --features=arbitrary` still causes `indexmap` to be built.