### PR TITLE
Replace impossible error conditions with debug assertions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,25 +15,19 @@ pub(crate) enum Repr {
     TrailingComma(usize),
     TrailingCharactersAfterParsedValue(usize),
 
-    ExpectedStartOfInnerList(usize),
     ExpectedInnerListDelimiter(usize),
     UnterminatedInnerList(usize),
 
     ExpectedStartOfBareItem(usize),
 
-    ExpectedStartOfBoolean(usize),
     ExpectedBoolean(usize),
 
-    ExpectedStartOfString(usize),
     InvalidStringCharacter(usize),
     UnterminatedString(usize),
 
     UnterminatedEscapeSequence(usize),
     InvalidEscapeSequence(usize),
 
-    ExpectedStartOfToken(usize),
-
-    ExpectedStartOfByteSequence(usize),
     UnterminatedByteSequence(usize),
     InvalidByteSequence(usize),
 
@@ -43,11 +37,9 @@ pub(crate) enum Repr {
     TooManyDigitsAfterDecimalPoint(usize),
     TrailingDecimalPoint(usize),
 
-    ExpectedStartOfDate(usize),
     Rfc8941Date(usize),
     NonIntegerDate(usize),
 
-    ExpectedStartOfDisplayString(usize),
     Rfc8941DisplayString(usize),
     ExpectedQuote(usize),
     InvalidUtf8InDisplayString(usize),
@@ -80,7 +72,6 @@ impl Repr {
                 ("trailing characters after parsed value", Some(i))
             }
 
-            Self::ExpectedStartOfInnerList(i) => ("expected start of inner list", Some(i)),
             Self::ExpectedInnerListDelimiter(i) => {
                 ("expected inner list delimiter (' ' or ')')", Some(i))
             }
@@ -88,21 +79,14 @@ impl Repr {
 
             Self::ExpectedStartOfBareItem(i) => ("expected start of bare item", Some(i)),
 
-            Self::ExpectedStartOfBoolean(i) => ("expected start of boolean ('?')", Some(i)),
             Self::ExpectedBoolean(i) => ("expected boolean ('0' or '1')", Some(i)),
 
-            Self::ExpectedStartOfString(i) => (r#"expected start of string ('"')"#, Some(i)),
             Self::InvalidStringCharacter(i) => ("invalid string character", Some(i)),
             Self::UnterminatedString(i) => ("unterminated string", Some(i)),
 
             Self::UnterminatedEscapeSequence(i) => ("unterminated escape sequence", Some(i)),
             Self::InvalidEscapeSequence(i) => ("invalid escape sequence", Some(i)),
 
-            Self::ExpectedStartOfToken(i) => ("expected start of token", Some(i)),
-
-            Self::ExpectedStartOfByteSequence(i) => {
-                ("expected start of byte sequence (':')", Some(i))
-            }
             Self::UnterminatedByteSequence(i) => ("unterminated byte sequence", Some(i)),
             Self::InvalidByteSequence(i) => ("invalid byte sequence", Some(i)),
 
@@ -116,13 +100,9 @@ impl Repr {
             }
             Self::TrailingDecimalPoint(i) => ("trailing decimal point", Some(i)),
 
-            Self::ExpectedStartOfDate(i) => ("expected start of date ('@')", Some(i)),
             Self::Rfc8941Date(i) => ("RFC 8941 does not support dates", Some(i)),
             Self::NonIntegerDate(i) => ("date must be an integer number of seconds", Some(i)),
 
-            Self::ExpectedStartOfDisplayString(i) => {
-                ("expected start of display string ('%')", Some(i))
-            }
             Self::Rfc8941DisplayString(i) => ("RFC 8941 does not support display strings", Some(i)),
             Self::ExpectedQuote(i) => (r#"expected '"'"#, Some(i)),
             Self::InvalidUtf8InDisplayString(i) => ("invalid UTF-8 in display string", Some(i)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -227,10 +227,7 @@ assert_eq!(
     ) -> Result<(), error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-innerlist
 
-        if Some(b'(') != self.peek() {
-            return Err(error::Repr::ExpectedStartOfInnerList(self.index));
-        }
-
+        debug_assert_eq!(self.peek(), Some(b'('));
         self.next();
 
         while self.peek().is_some() {
@@ -264,7 +261,7 @@ assert_eq!(
             Some(b'@') => BareItemFromInput::Date(self.parse_date()?),
             Some(b'%') => BareItemFromInput::DisplayString(self.parse_display_string()?),
             Some(c) if utils::is_allowed_start_token_char(c) => {
-                BareItemFromInput::Token(self.parse_token()?)
+                BareItemFromInput::Token(self.parse_token())
             }
             Some(c) if c == b'-' || c.is_ascii_digit() => match self.parse_number()? {
                 Num::Decimal(val) => BareItemFromInput::Decimal(val),
@@ -277,10 +274,7 @@ assert_eq!(
     pub(crate) fn parse_bool(&mut self) -> Result<bool, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-boolean
 
-        if self.peek() != Some(b'?') {
-            return Err(error::Repr::ExpectedStartOfBoolean(self.index));
-        }
-
+        debug_assert_eq!(self.peek(), Some(b'?'));
         self.next();
 
         match self.peek() {
@@ -299,10 +293,7 @@ assert_eq!(
     pub(crate) fn parse_string(&mut self) -> Result<Cow<'de, StringRef>, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-string
 
-        if self.peek() != Some(b'"') {
-            return Err(error::Repr::ExpectedStartOfString(self.index));
-        }
-
+        debug_assert_eq!(self.peek(), Some(b'"'));
         self.next();
 
         let start = self.index;
@@ -351,19 +342,10 @@ assert_eq!(
         Err(error::Repr::UnterminatedString(self.index))
     }
 
-    fn parse_non_empty_str(
-        &mut self,
-        is_allowed_start_char: impl FnOnce(u8) -> bool,
-        is_allowed_inner_char: impl Fn(u8) -> bool,
-    ) -> Option<&'de str> {
+    fn parse_non_empty_str(&mut self, is_allowed_inner_char: impl Fn(u8) -> bool) -> &'de str {
+        debug_assert!(self.peek().is_some());
         let start = self.index;
-
-        match self.peek() {
-            Some(c) if is_allowed_start_char(c) => {
-                self.next();
-            }
-            _ => return None,
-        }
+        self.next();
 
         loop {
             match self.peek() {
@@ -372,30 +354,23 @@ assert_eq!(
                 }
                 // TODO: The UTF-8 validation is redundant with the preceding character checks, but
                 // its removal is only possible with unsafe code.
-                _ => return Some(std::str::from_utf8(&self.input[start..self.index]).unwrap()),
+                _ => return std::str::from_utf8(&self.input[start..self.index]).unwrap(),
             }
         }
     }
 
-    pub(crate) fn parse_token(&mut self) -> Result<&'de TokenRef, error::Repr> {
+    pub(crate) fn parse_token(&mut self) -> &'de TokenRef {
         // https://httpwg.org/specs/rfc9651.html#parse-token
 
-        match self.parse_non_empty_str(
-            utils::is_allowed_start_token_char,
-            utils::is_allowed_inner_token_char,
-        ) {
-            None => Err(error::Repr::ExpectedStartOfToken(self.index)),
-            Some(str) => Ok(TokenRef::from_validated_str(str)),
-        }
+        debug_assert!(self.peek().is_some_and(utils::is_allowed_start_token_char));
+
+        TokenRef::from_validated_str(self.parse_non_empty_str(utils::is_allowed_inner_token_char))
     }
 
     pub(crate) fn parse_byte_sequence(&mut self) -> Result<Vec<u8>, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-binary
 
-        if self.peek() != Some(b':') {
-            return Err(error::Repr::ExpectedStartOfByteSequence(self.index));
-        }
-
+        debug_assert_eq!(self.peek(), Some(b':'));
         self.next();
         let start = self.index;
 
@@ -500,9 +475,7 @@ assert_eq!(
     pub(crate) fn parse_date(&mut self) -> Result<Date, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-date
 
-        if self.peek() != Some(b'@') {
-            return Err(error::Repr::ExpectedStartOfDate(self.index));
-        }
+        debug_assert_eq!(self.peek(), Some(b'@'));
 
         match self.version {
             Version::Rfc8941 => return Err(error::Repr::Rfc8941Date(self.index)),
@@ -521,9 +494,7 @@ assert_eq!(
     pub(crate) fn parse_display_string(&mut self) -> Result<Cow<'de, str>, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-display
 
-        if self.peek() != Some(b'%') {
-            return Err(error::Repr::ExpectedStartOfDisplayString(self.index));
-        }
+        debug_assert_eq!(self.peek(), Some(b'%'));
 
         match self.version {
             Version::Rfc8941 => return Err(error::Repr::Rfc8941DisplayString(self.index)),
@@ -631,13 +602,13 @@ assert_eq!(
     pub(crate) fn parse_key(&mut self) -> Result<&'de KeyRef, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-key
 
-        match self.parse_non_empty_str(
-            utils::is_allowed_start_key_char,
-            utils::is_allowed_inner_key_char,
-        ) {
-            None => Err(error::Repr::ExpectedStartOfKey(self.index)),
-            Some(str) => Ok(KeyRef::from_validated_str(str)),
+        if !self.peek().is_some_and(utils::is_allowed_start_key_char) {
+            return Err(error::Repr::ExpectedStartOfKey(self.index));
         }
+
+        Ok(KeyRef::from_validated_str(
+            self.parse_non_empty_str(utils::is_allowed_inner_key_char),
+        ))
     }
 
     fn consume_ows_chars(&mut self) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -227,7 +227,7 @@ assert_eq!(
     ) -> Result<(), error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-innerlist
 
-        debug_assert_eq!(self.peek(), Some(b'('));
+        debug_assert_eq!(self.peek(), Some(b'('), "expected start of inner list");
         self.next();
 
         while self.peek().is_some() {
@@ -274,7 +274,7 @@ assert_eq!(
     pub(crate) fn parse_bool(&mut self) -> Result<bool, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-boolean
 
-        debug_assert_eq!(self.peek(), Some(b'?'));
+        debug_assert_eq!(self.peek(), Some(b'?'), "expected start of boolean");
         self.next();
 
         match self.peek() {
@@ -293,7 +293,7 @@ assert_eq!(
     pub(crate) fn parse_string(&mut self) -> Result<Cow<'de, StringRef>, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-string
 
-        debug_assert_eq!(self.peek(), Some(b'"'));
+        debug_assert_eq!(self.peek(), Some(b'"'), "expected start of string");
         self.next();
 
         let start = self.index;
@@ -362,7 +362,10 @@ assert_eq!(
     pub(crate) fn parse_token(&mut self) -> &'de TokenRef {
         // https://httpwg.org/specs/rfc9651.html#parse-token
 
-        debug_assert!(self.peek().is_some_and(utils::is_allowed_start_token_char));
+        debug_assert!(
+            self.peek().is_some_and(utils::is_allowed_start_token_char),
+            "expected start of token"
+        );
 
         TokenRef::from_validated_str(self.parse_non_empty_str(utils::is_allowed_inner_token_char))
     }
@@ -370,7 +373,7 @@ assert_eq!(
     pub(crate) fn parse_byte_sequence(&mut self) -> Result<Vec<u8>, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-binary
 
-        debug_assert_eq!(self.peek(), Some(b':'));
+        debug_assert_eq!(self.peek(), Some(b':'), "expected start of byte sequence");
         self.next();
         let start = self.index;
 
@@ -475,7 +478,7 @@ assert_eq!(
     pub(crate) fn parse_date(&mut self) -> Result<Date, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-date
 
-        debug_assert_eq!(self.peek(), Some(b'@'));
+        debug_assert_eq!(self.peek(), Some(b'@'), "expected start of date");
 
         match self.version {
             Version::Rfc8941 => return Err(error::Repr::Rfc8941Date(self.index)),
@@ -494,7 +497,7 @@ assert_eq!(
     pub(crate) fn parse_display_string(&mut self) -> Result<Cow<'de, str>, error::Repr> {
         // https://httpwg.org/specs/rfc9651.html#parse-display
 
-        debug_assert_eq!(self.peek(), Some(b'%'));
+        debug_assert_eq!(self.peek(), Some(b'%'), "expected start of display string");
 
         match self.version {
             Version::Rfc8941 => return Err(error::Repr::Rfc8941DisplayString(self.index)),

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -193,13 +193,14 @@ fn parse_list_errors() {
 }
 
 #[test]
-fn parse_inner_list_errors() {
-    let input = "c b); a=1";
-    assert_eq!(
-        Err(error::Repr::ExpectedStartOfInnerList(0)),
-        Parser::new(input).parse_inner_list(Ignored)
-    );
+#[should_panic]
+#[cfg(debug_assertions)]
+fn parse_invalid_inner_list_start() {
+    let _ = Parser::new("c b); a=1").parse_inner_list(Ignored);
+}
 
+#[test]
+fn parse_inner_list_errors() {
     let input = "(";
     assert_eq!(
         Err(error::Repr::UnterminatedInnerList(1)),
@@ -412,11 +413,14 @@ fn parse_bool() -> Result<(), Error> {
 }
 
 #[test]
+#[should_panic]
+#[cfg(debug_assertions)]
+fn parse_invalid_bool_start() {
+    let _ = Parser::new("").parse_bool();
+}
+
+#[test]
 fn parse_bool_errors() {
-    assert_eq!(
-        Err(error::Repr::ExpectedStartOfBoolean(0)),
-        Parser::new("").parse_bool()
-    );
     assert_eq!(
         Err(error::Repr::ExpectedBoolean(1)),
         Parser::new("?").parse_bool()
@@ -443,11 +447,14 @@ fn parse_string() -> Result<(), Error> {
 }
 
 #[test]
+#[should_panic]
+#[cfg(debug_assertions)]
+fn parse_invalid_string_start() {
+    let _ = Parser::new("test").parse_string();
+}
+
+#[test]
 fn parse_string_errors() {
-    assert_eq!(
-        Err(error::Repr::ExpectedStartOfString(0)),
-        Parser::new("test").parse_string()
-    );
     assert_eq!(
         Err(error::Repr::UnterminatedEscapeSequence(2)),
         Parser::new(r#""\"#).parse_string()
@@ -467,48 +474,41 @@ fn parse_string_errors() {
 }
 
 #[test]
-fn parse_token() -> Result<(), Error> {
+fn parse_token() {
     let mut parser = Parser::new("*some:token}not token");
-    assert_eq!(token_ref("*some:token"), parser.parse_token()?);
+    assert_eq!(token_ref("*some:token"), parser.parse_token());
     assert_eq!(parser.remaining(), b"}not token");
 
-    assert_eq!(token_ref("token"), Parser::new("token").parse_token()?);
+    assert_eq!(token_ref("token"), Parser::new("token").parse_token());
     assert_eq!(
         token_ref("a_b-c.d3:f%00/*"),
-        Parser::new("a_b-c.d3:f%00/*").parse_token()?
+        Parser::new("a_b-c.d3:f%00/*").parse_token()
     );
     assert_eq!(
         token_ref("TestToken"),
-        Parser::new("TestToken").parse_token()?
+        Parser::new("TestToken").parse_token()
     );
-    assert_eq!(token_ref("some"), Parser::new("some@token").parse_token()?);
+    assert_eq!(token_ref("some"), Parser::new("some@token").parse_token());
     assert_eq!(
         token_ref("*TestToken*"),
-        Parser::new("*TestToken*").parse_token()?
+        Parser::new("*TestToken*").parse_token()
     );
-    assert_eq!(token_ref("*"), Parser::new("*[@:token").parse_token()?);
-    assert_eq!(token_ref("test"), Parser::new("test token").parse_token()?);
-
-    Ok(())
+    assert_eq!(token_ref("*"), Parser::new("*[@:token").parse_token());
+    assert_eq!(token_ref("test"), Parser::new("test token").parse_token());
 }
 
 #[test]
-fn parse_token_errors() {
-    let mut parser = Parser::new("765token");
-    assert_eq!(
-        Err(error::Repr::ExpectedStartOfToken(0)),
-        parser.parse_token()
-    );
-    assert_eq!(parser.remaining(), b"765token");
+#[should_panic]
+#[cfg(debug_assertions)]
+fn parse_invalid_token_start() {
+    let _ = Parser::new("7").parse_token();
+}
 
-    assert_eq!(
-        Err(error::Repr::ExpectedStartOfToken(0)),
-        Parser::new("7token").parse_token()
-    );
-    assert_eq!(
-        Err(error::Repr::ExpectedStartOfToken(0)),
-        Parser::new("").parse_token()
-    );
+#[test]
+#[should_panic]
+#[cfg(debug_assertions)]
+fn parse_empty_token_start() {
+    let _ = Parser::new("").parse_token();
 }
 
 #[test]
@@ -534,11 +534,14 @@ fn parse_byte_sequence() -> Result<(), Error> {
 }
 
 #[test]
+#[should_panic]
+#[cfg(debug_assertions)]
+fn parse_invalid_byte_sequence_start() {
+    let _ = Parser::new("aGVsbG8").parse_byte_sequence();
+}
+
+#[test]
 fn parse_byte_sequence_errors() {
-    assert_eq!(
-        Err(error::Repr::ExpectedStartOfByteSequence(0)),
-        Parser::new("aGVsbG8").parse_byte_sequence()
-    );
     assert_eq!(
         Err(error::Repr::InvalidByteSequence(6)),
         Parser::new(":aGVsb G8=:").parse_byte_sequence()

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -193,7 +193,7 @@ fn parse_list_errors() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "expected start of inner list"]
 #[cfg(debug_assertions)]
 fn parse_invalid_inner_list_start() {
     let _ = Parser::new("c b); a=1").parse_inner_list(Ignored);
@@ -413,7 +413,7 @@ fn parse_bool() -> Result<(), Error> {
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "expected start of boolean"]
 #[cfg(debug_assertions)]
 fn parse_invalid_bool_start() {
     let _ = Parser::new("").parse_bool();
@@ -447,7 +447,7 @@ fn parse_string() -> Result<(), Error> {
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "expected start of string"]
 #[cfg(debug_assertions)]
 fn parse_invalid_string_start() {
     let _ = Parser::new("test").parse_string();
@@ -498,14 +498,14 @@ fn parse_token() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "expected start of token"]
 #[cfg(debug_assertions)]
 fn parse_invalid_token_start() {
     let _ = Parser::new("7").parse_token();
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "expected start of token"]
 #[cfg(debug_assertions)]
 fn parse_empty_token_start() {
     let _ = Parser::new("").parse_token();
@@ -534,7 +534,7 @@ fn parse_byte_sequence() -> Result<(), Error> {
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "expected start of byte sequence"]
 #[cfg(debug_assertions)]
 fn parse_invalid_byte_sequence_start() {
     let _ = Parser::new("aGVsbG8").parse_byte_sequence();
@@ -860,7 +860,7 @@ fn parse_date() -> Result<(), Error> {
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "expected start of date"]
 #[cfg(debug_assertions)]
 fn parse_invalid_date_start() {
     let _ = Parser::new("7").parse_date();
@@ -926,7 +926,7 @@ fn parse_display_string_errors() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "expected start of display string"]
 #[cfg(debug_assertions)]
 fn parse_invalid_display_string_start() {
     let _ = Parser::new(r#"""#).parse_display_string();

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -860,6 +860,13 @@ fn parse_date() -> Result<(), Error> {
 }
 
 #[test]
+#[should_panic]
+#[cfg(debug_assertions)]
+fn parse_invalid_date_start() {
+    let _ = Parser::new("7").parse_date();
+}
+
+#[test]
 #[cfg(feature = "parsed-types")]
 fn parse_display_string() -> Result<(), Error> {
     let input = r#"%"This is intended for display to %c3%bcsers.""#;
@@ -916,6 +923,13 @@ fn parse_display_string_errors() {
         Parser::new(r#" %"x%aa""#).parse::<Item>(),
         Err(error::Repr::InvalidUtf8InDisplayString(4).into())
     );
+}
+
+#[test]
+#[should_panic]
+#[cfg(debug_assertions)]
+fn parse_invalid_display_string_start() {
+    let _ = Parser::new(r#"""#).parse_display_string();
 }
 
 /// A simple struct used for the complex tests.


### PR DESCRIPTION
These conditions are only possible when the individual bare-item parsing
methods are called directly, but that is only possible in tests.