### PR TITLE
Replace Result with Option in list/dictionary serialization

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -60,7 +60,7 @@ fn serializing_item(c: &mut Criterion) {
         &fixture,
         move |bench, &input| {
             let parsed_item = Parser::new(input).parse_item().unwrap();
-            bench.iter(|| parsed_item.serialize_value().unwrap());
+            bench.iter(|| parsed_item.serialize_value());
         },
     );
 }

--- a/fuzz/fuzz_targets/roundtrip_dictionary.rs
+++ b/fuzz/fuzz_targets/roundtrip_dictionary.rs
@@ -6,7 +6,7 @@ use sfv::SerializeValue as _;
 fuzz_target!(|dict: sfv::Dictionary| {
     let serialized = dict.serialize_value();
     if dict.is_empty() {
-        assert!(serialized.is_err());
+        assert!(serialized.is_none());
     } else {
         assert_eq!(
             sfv::Parser::new(&serialized.unwrap())

--- a/fuzz/fuzz_targets/roundtrip_item.rs
+++ b/fuzz/fuzz_targets/roundtrip_item.rs
@@ -4,6 +4,6 @@ use libfuzzer_sys::fuzz_target;
 use sfv::SerializeValue as _;
 
 fuzz_target!(|item: sfv::Item| {
-    let serialized = item.serialize_value().unwrap();
+    let serialized = item.serialize_value();
     assert_eq!(sfv::Parser::new(&serialized).parse_item().unwrap(), item);
 });

--- a/fuzz/fuzz_targets/roundtrip_list.rs
+++ b/fuzz/fuzz_targets/roundtrip_list.rs
@@ -6,7 +6,7 @@ use sfv::SerializeValue as _;
 fuzz_target!(|list: sfv::List| {
     let serialized = list.serialize_value();
     if list.is_empty() {
-        assert!(serialized.is_err());
+        assert!(serialized.is_none());
     } else {
         assert_eq!(
             sfv::Parser::new(&serialized.unwrap()).parse_list().unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,11 +107,9 @@ ser.bare_item(TokenRef::from_str("tok")?);
     ser.finish().parameter(KeyRef::from_str("bar")?, true);
 }
 
-let serialized_list = ser.finish()?;
-
 assert_eq!(
-    serialized_list,
-    r#"tok, (99;key=?0 "foo");bar"#
+    ser.finish().as_deref(),
+    Some(r#"tok, (99;key=?0 "foo");bar"#),
 );
 # Ok(())
 # }
@@ -130,11 +128,9 @@ ser.bare_item(KeyRef::from_str("key2")?, true);
 
 ser.bare_item(KeyRef::from_str("key3")?, false);
 
-let serialized_dict = ser.finish()?;
-
 assert_eq!(
-    serialized_dict,
-    r#"key1="apple", key2, key3=?0"#
+    ser.finish().as_deref(),
+    Some(r#"key1="apple", key2, key3=?0"#),
 );
 # Ok(())
 # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,3 +624,7 @@ impl fmt::Display for Version {
         })
     }
 }
+
+mod private {
+    pub trait Sealed {}
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -101,8 +101,8 @@ let mut dict = Parser::new("a=1").parse_dictionary()?;
 Parser::new("b=2").parse_dictionary_with_visitor(&mut dict)?;
 
 assert_eq!(
-    dict.serialize_value()?,
-    "a=1, b=2",
+    dict.serialize_value().as_deref(),
+    Some("a=1, b=2"),
 );
 # Ok(())
 # }
@@ -155,8 +155,8 @@ let mut list = Parser::new("11, (12 13)").parse_list()?;
 Parser::new(r#""foo",        "bar""#).parse_list_with_visitor(&mut list)?;
 
 assert_eq!(
-    list.serialize_value()?,
-    r#"11, (12 13), "foo", "bar""#,
+    list.serialize_value().as_deref(),
+    Some(r#"11, (12 13), "foo", "bar""#),
 );
 # Ok(())
 # }

--- a/src/ref_serializer.rs
+++ b/src/ref_serializer.rs
@@ -1,5 +1,5 @@
 use crate::serializer::Serializer;
-use crate::{Error, KeyRef, RefBareItem, SFVResult};
+use crate::{KeyRef, RefBareItem};
 
 #[cfg(feature = "parsed-types")]
 use crate::{Item, ListEntry};
@@ -146,8 +146,8 @@ fn maybe_write_separator(buffer: &mut String, first: &mut bool) {
 /// }
 ///
 /// assert_eq!(
-///     ser.finish()?,
-///     r#"11;foo, (abc;abc_param=?0 def);bar="val""#
+///     ser.finish().as_deref(),
+///     Some(r#"11;foo, (abc;abc_param=?0 def);bar="val""#),
 /// );
 /// # Ok(())
 /// # }
@@ -229,14 +229,15 @@ impl<W: BorrowMut<String>> ListSerializer<W> {
 
     /// Finishes serialization of the list and returns the underlying output.
     ///
-    /// This can only fail if no members were serialized, as [empty lists are
-    /// not meant to be serialized at
+    /// Returns `None` if and only if no members were serialized, as [empty
+    /// lists are not meant to be serialized at
     /// all](https://httpwg.org/specs/rfc9651.html#text-serialize).
-    pub fn finish(self) -> SFVResult<W> {
+    pub fn finish(self) -> Option<W> {
         if self.first {
-            return Err(Error::new("serializing empty list is not allowed"));
+            None
+        } else {
+            Some(self.buffer)
         }
-        Ok(self.buffer)
     }
 }
 
@@ -275,8 +276,8 @@ impl<W: BorrowMut<String>> ListSerializer<W> {
 /// ser.bare_item(KeyRef::from_str("member3")?, Decimal::try_from(12.34566)?);
 ///
 /// assert_eq!(
-///     ser.finish()?,
-///     r#"member1=11;foo, member2=(abc;abc_param=?0 def);bar="val", member3=12.346"#
+///     ser.finish().as_deref(),
+///     Some(r#"member1=11;foo, member2=(abc;abc_param=?0 def);bar="val", member3=12.346"#),
 /// );
 /// # Ok(())
 /// # }
@@ -370,14 +371,15 @@ impl<W: BorrowMut<String>> DictSerializer<W> {
 
     /// Finishes serialization of the dictionary and returns the underlying output.
     ///
-    /// This can only fail if no members were serialized, as [empty dictionaries
-    /// are not meant to be serialized at
+    /// Returns `None` if and only if no members were serialized, as [empty
+    /// dictionaries are not meant to be serialized at
     /// all](https://httpwg.org/specs/rfc9651.html#text-serialize).
-    pub fn finish(self) -> SFVResult<W> {
+    pub fn finish(self) -> Option<W> {
         if self.first {
-            return Err(Error::new("serializing empty dictionary is not allowed"));
+            None
+        } else {
+            Some(self.buffer)
         }
-        Ok(self.buffer)
     }
 }
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -3,7 +3,7 @@ use crate::{Date, Decimal, Integer, KeyRef, RefBareItem, StringRef, TokenRef};
 use std::fmt::Write as _;
 
 #[cfg(feature = "parsed-types")]
-use crate::{Dictionary, Item, List};
+use crate::{private::Sealed, Dictionary, Item, List};
 
 /// Serializes a structured field value into a string.
 ///
@@ -16,7 +16,7 @@ use crate::{Dictionary, Item, List};
 /// [RFC 8941]: <https://httpwg.org/specs/rfc8941.html>
 /// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html>
 #[cfg(feature = "parsed-types")]
-pub trait SerializeValue {
+pub trait SerializeValue: Sealed {
     /// The result of serializing the value into a string.
     ///
     /// [`Item`] serialization is infallible; [`List`] and [`Dictionary`]
@@ -42,6 +42,9 @@ pub trait SerializeValue {
 }
 
 #[cfg(feature = "parsed-types")]
+impl Sealed for Dictionary {}
+
+#[cfg(feature = "parsed-types")]
 impl SerializeValue for Dictionary {
     type Result = Option<String>;
 
@@ -53,6 +56,9 @@ impl SerializeValue for Dictionary {
 }
 
 #[cfg(feature = "parsed-types")]
+impl Sealed for List {}
+
+#[cfg(feature = "parsed-types")]
 impl SerializeValue for List {
     type Result = Option<String>;
 
@@ -62,6 +68,9 @@ impl SerializeValue for List {
         ser.finish()
     }
 }
+
+#[cfg(feature = "parsed-types")]
+impl Sealed for Item {}
 
 #[cfg(feature = "parsed-types")]
 impl SerializeValue for Item {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -15,6 +15,10 @@ use crate::{private::Sealed, Dictionary, Item, List};
 ///
 /// [RFC 8941]: <https://httpwg.org/specs/rfc8941.html>
 /// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html>
+///
+/// Use [`crate::ItemSerializer`], [`crate::ListSerializer`], or
+/// [`crate::DictSerializer`] to serialize components incrementally without
+/// having to create an [`Item`], [`List`], or [`Dictionary`].
 #[cfg(feature = "parsed-types")]
 pub trait SerializeValue: Sealed {
     /// The result of serializing the value into a string.

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -3,7 +3,7 @@ use crate::{Date, Decimal, Integer, KeyRef, RefBareItem, StringRef, TokenRef};
 use std::fmt::Write as _;
 
 #[cfg(feature = "parsed-types")]
-use crate::{Dictionary, Item, List, SFVResult};
+use crate::{Dictionary, Item, List};
 
 /// Serializes a structured field value into a string.
 ///
@@ -26,18 +26,18 @@ pub trait SerializeValue {
     /// let parsed_list_field = Parser::new(r#" "london",   "berlin" "#).parse_list()?;
     ///
     /// assert_eq!(
-    ///     parsed_list_field.serialize_value()?,
-    ///     r#""london", "berlin""#
+    ///     parsed_list_field.serialize_value().as_deref(),
+    ///     Some(r#""london", "berlin""#),
     /// );
     /// # Ok(())
     /// # }
     /// ```
-    fn serialize_value(&self) -> SFVResult<String>;
+    fn serialize_value(&self) -> Option<String>;
 }
 
 #[cfg(feature = "parsed-types")]
 impl SerializeValue for Dictionary {
-    fn serialize_value(&self) -> SFVResult<String> {
+    fn serialize_value(&self) -> Option<String> {
         let mut ser = crate::DictSerializer::new();
         ser.members(self);
         ser.finish()
@@ -46,7 +46,7 @@ impl SerializeValue for Dictionary {
 
 #[cfg(feature = "parsed-types")]
 impl SerializeValue for List {
-    fn serialize_value(&self) -> SFVResult<String> {
+    fn serialize_value(&self) -> Option<String> {
         let mut ser = crate::ListSerializer::new();
         ser.members(self);
         ser.finish()
@@ -55,11 +55,13 @@ impl SerializeValue for List {
 
 #[cfg(feature = "parsed-types")]
 impl SerializeValue for Item {
-    fn serialize_value(&self) -> SFVResult<String> {
-        Ok(crate::ItemSerializer::new()
-            .bare_item(&self.bare_item)
-            .parameters(&self.params)
-            .finish())
+    fn serialize_value(&self) -> Option<String> {
+        Some(
+            crate::ItemSerializer::new()
+                .bare_item(&self.bare_item)
+                .parameters(&self.params)
+                .finish(),
+        )
     }
 }
 

--- a/src/test_ref_serializer.rs
+++ b/src/test_ref_serializer.rs
@@ -20,8 +20,8 @@ fn test_fast_serialize_item() {
 }
 
 #[test]
-fn test_fast_serialize_list() -> SFVResult<()> {
-    fn check(mut ser: ListSerializer<impl BorrowMut<String>>) -> SFVResult<()> {
+fn test_fast_serialize_list() {
+    fn check(mut ser: ListSerializer<impl BorrowMut<String>>) {
         ser.bare_item(token_ref("hello"))
             .parameter(key_ref("key1"), true)
             .parameter(key_ref("key2"), false);
@@ -35,22 +35,19 @@ fn test_fast_serialize_list() -> SFVResult<()> {
                 .parameter(key_ref("inner-list-param"), token_ref("*"));
         }
 
-        let output = ser.finish()?;
         assert_eq!(
-            r#"hello;key1;key2=?0, ("some_string" 12;inner-member-key);inner-list-param=*"#,
-            output.borrow()
+            Some(r#"hello;key1;key2=?0, ("some_string" 12;inner-member-key);inner-list-param=*"#),
+            ser.finish().as_ref().map(|output| output.borrow().as_str()),
         );
-        Ok(())
     }
 
-    check(ListSerializer::new())?;
-    check(ListSerializer::with_buffer(&mut String::new()))?;
-    Ok(())
+    check(ListSerializer::new());
+    check(ListSerializer::with_buffer(&mut String::new()));
 }
 
 #[test]
-fn test_fast_serialize_dict() -> SFVResult<()> {
-    fn check(mut ser: DictSerializer<impl BorrowMut<String>>) -> SFVResult<()> {
+fn test_fast_serialize_dict() {
+    fn check(mut ser: DictSerializer<impl BorrowMut<String>>) {
         ser.bare_item(key_ref("member1"), token_ref("hello"))
             .parameter(key_ref("key1"), true)
             .parameter(key_ref("key2"), false);
@@ -76,29 +73,28 @@ fn test_fast_serialize_dict() -> SFVResult<()> {
 
         ser.bare_item(key_ref("key8"), true);
 
-        let output = ser.finish()?;
         assert_eq!(
-            r#"member1=hello;key1;key2=?0, member2;key3=45.459;key4="str", key5=(45 0), key6="foo", key7=(:c29tZV9zdHJpbmc=: :b3RoZXJfc3RyaW5n:);lparam=10, key8"#,
-            output.borrow()
+            Some(
+                r#"member1=hello;key1;key2=?0, member2;key3=45.459;key4="str", key5=(45 0), key6="foo", key7=(:c29tZV9zdHJpbmc=: :b3RoZXJfc3RyaW5n:);lparam=10, key8"#
+            ),
+            ser.finish().as_ref().map(|output| output.borrow().as_str()),
         );
-        Ok(())
     }
 
-    check(DictSerializer::new())?;
-    check(DictSerializer::with_buffer(&mut String::new()))?;
-    Ok(())
+    check(DictSerializer::new());
+    check(DictSerializer::with_buffer(&mut String::new()));
 }
 
 #[test]
 fn test_serialize_empty() {
-    assert!(ListSerializer::new().finish().is_err());
-    assert!(DictSerializer::new().finish().is_err());
+    assert_eq!(None, ListSerializer::new().finish());
+    assert_eq!(None, DictSerializer::new().finish());
 
     let mut output = String::from(" ");
-    assert!(ListSerializer::with_buffer(&mut output).finish().is_err());
+    assert_eq!(None, ListSerializer::with_buffer(&mut output).finish());
 
     let mut output = String::from(" ");
-    assert!(DictSerializer::with_buffer(&mut output).finish().is_err());
+    assert_eq!(None, DictSerializer::with_buffer(&mut output).finish());
 }
 
 // Regression test for https://github.com/undef1nd/sfv/issues/131.

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -64,17 +64,14 @@ fn serialize_item_byteseq_with_param() {
     );
     let item_param = Parameters::from_iter(vec![item_param]);
     let item = Item::with_params(b"parser".to_vec(), item_param);
-    assert_eq!(
-        Some(":cGFyc2Vy:;a=*ab_1"),
-        item.serialize_value().as_deref(),
-    );
+    assert_eq!(":cGFyc2Vy:;a=*ab_1", item.serialize_value());
 }
 
 #[test]
 #[cfg(feature = "parsed-types")]
 fn serialize_item_without_params() {
     let item = Item::new(1);
-    assert_eq!(Some("1"), item.serialize_value().as_deref());
+    assert_eq!("1", item.serialize_value());
 }
 
 #[test]
@@ -82,7 +79,7 @@ fn serialize_item_without_params() {
 fn serialize_item_with_bool_true_param() -> Result<(), Error> {
     let param = Parameters::from_iter(vec![(key_ref("a").to_owned(), BareItem::Boolean(true))]);
     let item = Item::with_params(Decimal::try_from(12.35)?, param);
-    assert_eq!(Some("12.35;a"), item.serialize_value().as_deref());
+    assert_eq!("12.35;a", item.serialize_value());
     Ok(())
 }
 
@@ -94,10 +91,7 @@ fn serialize_item_with_token_param() {
         BareItem::Token(token_ref("*tok").to_owned()),
     )]);
     let item = Item::with_params(string_ref("12.35"), param);
-    assert_eq!(
-        Some(r#""12.35";a1=*tok"#),
-        item.serialize_value().as_deref(),
-    );
+    assert_eq!(r#""12.35";a1=*tok"#, item.serialize_value());
 }
 
 #[test]

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -8,20 +8,14 @@ use crate::{BareItem, Dictionary, InnerList, Item, List, Parameters, SerializeVa
 #[cfg(feature = "parsed-types")]
 fn serialize_value_empty_dict() {
     let dict_field_value = Dictionary::new();
-    assert_eq!(
-        Err(Error::new("serializing empty dictionary is not allowed")),
-        dict_field_value.serialize_value()
-    );
+    assert_eq!(None, dict_field_value.serialize_value());
 }
 
 #[test]
 #[cfg(feature = "parsed-types")]
 fn serialize_value_empty_list() {
     let list_field_value = List::new();
-    assert_eq!(
-        Err(Error::new("serializing empty list is not allowed")),
-        list_field_value.serialize_value()
-    );
+    assert_eq!(None, list_field_value.serialize_value());
 }
 
 #[test]
@@ -52,30 +46,35 @@ fn serialize_value_list_mixed_members_with_params() -> Result<(), Error> {
         InnerList::with_params(vec![inner_list_item1, inner_list_item2], inner_list_param);
 
     let list_field_value: List = vec![item1.into(), item2.into(), inner_list.into()];
-    let expected = r#"42.457, 17;itm2_p, ("str1";in1_p=?0 str2;in2_p="valu\\e");inner_list_param=:d2VhdGhlcg==:"#;
-    assert_eq!(expected, list_field_value.serialize_value()?);
+    assert_eq!(
+        Some(
+            r#"42.457, 17;itm2_p, ("str1";in1_p=?0 str2;in2_p="valu\\e");inner_list_param=:d2VhdGhlcg==:"#
+        ),
+        list_field_value.serialize_value().as_deref(),
+    );
     Ok(())
 }
 
 #[test]
 #[cfg(feature = "parsed-types")]
-fn serialize_item_byteseq_with_param() -> Result<(), Error> {
+fn serialize_item_byteseq_with_param() {
     let item_param = (
         key_ref("a").to_owned(),
         BareItem::Token(token_ref("*ab_1").to_owned()),
     );
     let item_param = Parameters::from_iter(vec![item_param]);
     let item = Item::with_params(b"parser".to_vec(), item_param);
-    assert_eq!(":cGFyc2Vy:;a=*ab_1", item.serialize_value()?);
-    Ok(())
+    assert_eq!(
+        Some(":cGFyc2Vy:;a=*ab_1"),
+        item.serialize_value().as_deref(),
+    );
 }
 
 #[test]
 #[cfg(feature = "parsed-types")]
-fn serialize_item_without_params() -> Result<(), Error> {
+fn serialize_item_without_params() {
     let item = Item::new(1);
-    assert_eq!("1", item.serialize_value()?);
-    Ok(())
+    assert_eq!(Some("1"), item.serialize_value().as_deref());
 }
 
 #[test]
@@ -83,20 +82,22 @@ fn serialize_item_without_params() -> Result<(), Error> {
 fn serialize_item_with_bool_true_param() -> Result<(), Error> {
     let param = Parameters::from_iter(vec![(key_ref("a").to_owned(), BareItem::Boolean(true))]);
     let item = Item::with_params(Decimal::try_from(12.35)?, param);
-    assert_eq!("12.35;a", item.serialize_value()?);
+    assert_eq!(Some("12.35;a"), item.serialize_value().as_deref());
     Ok(())
 }
 
 #[test]
 #[cfg(feature = "parsed-types")]
-fn serialize_item_with_token_param() -> Result<(), Error> {
+fn serialize_item_with_token_param() {
     let param = Parameters::from_iter(vec![(
         key_ref("a1").to_owned(),
         BareItem::Token(token_ref("*tok").to_owned()),
     )]);
     let item = Item::with_params(string_ref("12.35"), param);
-    assert_eq!(r#""12.35";a1=*tok"#, item.serialize_value()?);
-    Ok(())
+    assert_eq!(
+        Some(r#""12.35";a1=*tok"#),
+        item.serialize_value().as_deref(),
+    );
 }
 
 #[test]
@@ -306,7 +307,7 @@ fn serialize_key() {
 
 #[test]
 #[cfg(feature = "parsed-types")]
-fn serialize_list_of_items_and_inner_list() -> Result<(), Error> {
+fn serialize_list_of_items_and_inner_list() {
     let item1 = Item::new(12);
     let item2 = Item::new(14);
     let item3 = Item::new(token_ref("a"));
@@ -319,15 +320,14 @@ fn serialize_list_of_items_and_inner_list() -> Result<(), Error> {
     let input: List = vec![item1.into(), item2.into(), inner_list.into()];
 
     assert_eq!(
-        r#"12, 14, (a b);param="param_value_1""#,
-        input.serialize_value()?
+        Some(r#"12, 14, (a b);param="param_value_1""#),
+        input.serialize_value().as_deref(),
     );
-    Ok(())
 }
 
 #[test]
 #[cfg(feature = "parsed-types")]
-fn serialize_list_of_lists() -> Result<(), Error> {
+fn serialize_list_of_lists() {
     let item1 = Item::new(1);
     let item2 = Item::new(2);
     let item3 = Item::new(42);
@@ -336,13 +336,12 @@ fn serialize_list_of_lists() -> Result<(), Error> {
     let inner_list_2 = InnerList::new(vec![item3, item4]);
     let input: List = vec![inner_list_1.into(), inner_list_2.into()];
 
-    assert_eq!("(1 2), (42 43)", input.serialize_value()?);
-    Ok(())
+    assert_eq!(Some("(1 2), (42 43)"), input.serialize_value().as_deref());
 }
 
 #[test]
 #[cfg(feature = "parsed-types")]
-fn serialize_list_with_bool_item_and_bool_params() -> Result<(), Error> {
+fn serialize_list_with_bool_item_and_bool_params() {
     let item1_params = Parameters::from_iter(vec![
         (key_ref("a").to_owned(), BareItem::Boolean(true)),
         (key_ref("b").to_owned(), BareItem::Boolean(false)),
@@ -351,13 +350,15 @@ fn serialize_list_with_bool_item_and_bool_params() -> Result<(), Error> {
     let item2 = Item::new(token_ref("cde_456"));
 
     let input: List = vec![item1.into(), item2.into()];
-    assert_eq!("?0;a;b=?0, cde_456", input.serialize_value()?);
-    Ok(())
+    assert_eq!(
+        Some("?0;a;b=?0, cde_456"),
+        input.serialize_value().as_deref(),
+    );
 }
 
 #[test]
 #[cfg(feature = "parsed-types")]
-fn serialize_dictionary_with_params() -> Result<(), Error> {
+fn serialize_dictionary_with_params() {
     let item1_params = Parameters::from_iter(vec![
         (key_ref("a").to_owned(), 1.into()),
         (key_ref("b").to_owned(), BareItem::Boolean(true)),
@@ -382,19 +383,17 @@ fn serialize_dictionary_with_params() -> Result<(), Error> {
     ]);
 
     assert_eq!(
-        r#"abc=123;a=1;b, def=456, ghi=789;q=?0;r="+w""#,
-        input.serialize_value()?
+        Some(r#"abc=123;a=1;b, def=456, ghi=789;q=?0;r="+w""#),
+        input.serialize_value().as_deref(),
     );
-    Ok(())
 }
 
 #[test]
 #[cfg(feature = "parsed-types")]
-fn serialize_dict_empty_member_value() -> Result<(), Error> {
+fn serialize_dict_empty_member_value() {
     let inner_list = InnerList::new(vec![]);
     let input = Dictionary::from_iter(vec![(key_ref("a").to_owned(), inner_list.into())]);
-    assert_eq!("a=()", input.serialize_value()?);
-    Ok(())
+    assert_eq!(Some("a=()"), input.serialize_value().as_deref());
 }
 
 #[test]

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -107,7 +107,7 @@ impl TestCase for ParseTestData {
                             // If the canonical field is an empty list, the serialization
                             // should be omitted, which corresponds to an error from `serialize_value`.
                             if canonical.is_empty() {
-                                assert!(serialized.is_err());
+                                assert!(serialized.is_none());
                             } else {
                                 assert_eq!(
                                     serialized.expect("serialization should succeed"),
@@ -144,7 +144,7 @@ impl TestCase for TestData {
             println!("- {}", test_case.name);
             match value.expect("expected value should be present").build() {
                 Ok(value) => match value.serialize_value() {
-                    Ok(serialized) => {
+                    Some(serialized) => {
                         assert!(!test_case.must_fail);
                         assert_eq!(
                             serialized,
@@ -154,7 +154,7 @@ impl TestCase for TestData {
                                 .expect("canonical serialization should be present")[0]
                         )
                     }
-                    Err(_) => assert!(test_case.must_fail),
+                    None => assert!(test_case.must_fail),
                 },
                 Err(_) => assert!(test_case.must_fail),
             }

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -96,7 +96,7 @@ impl TestCase for ParseTestData {
                             .expect("build should succeed")
                     );
 
-                    let serialized = actual.serialize_value();
+                    let serialized: Option<String> = actual.serialize_value().into();
 
                     match test_case.data.canonical {
                         // If the canonical field is omitted, the canonical form is the input.
@@ -143,7 +143,7 @@ impl TestCase for TestData {
         fn check<T: SerializeValue>(test_case: &TestData, value: Option<impl Build<T>>) {
             println!("- {}", test_case.name);
             match value.expect("expected value should be present").build() {
-                Ok(value) => match value.serialize_value() {
+                Ok(value) => match value.serialize_value().into() {
                     Some(serialized) => {
                         assert!(!test_case.must_fail);
                         assert_eq!(


### PR DESCRIPTION
We also make `Item`'s `SerializeValue` implementation infallible using an associated type.

Fixes #170