### PR TITLE
Fix clippy::pedantic errors

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -117,18 +117,19 @@ fn serializing_ref_list(c: &mut Criterion) {
             let mut ser = ListSerializer::new();
             ser.bare_item(token_ref("a"));
             ser.bare_item(token_ref("abcdefghigklmnoprst"));
-            ser.bare_item(integer(123456785686457));
-            ser.bare_item(Decimal::try_from(99999999999.999).unwrap());
+            ser.bare_item(integer(123_456_785_686_457));
+            ser.bare_item(Decimal::try_from(99_999_999_999.999).unwrap());
             ser.inner_list();
             {
                 let mut ser = ser.inner_list();
-                ser.bare_item(string_ref("somelongstringvalue"));
-                ser.bare_item(string_ref("anotherlongstringvalue"))
+                _ = ser.bare_item(string_ref("somelongstringvalue"));
+                _ = ser
+                    .bare_item(string_ref("anotherlongstringvalue"))
                     .parameter(
                         key_ref("key"),
                         "somever longstringvaluerepresentedasbytes".as_bytes(),
                     );
-                ser.bare_item(145);
+                _ = ser.bare_item(145);
             }
             ser.finish()
         });
@@ -141,12 +142,13 @@ fn serializing_ref_dict(c: &mut Criterion) {
             let mut ser = DictSerializer::new();
             ser.bare_item(key_ref("a"), true);
             ser.bare_item(key_ref("dict_key2"), token_ref("abcdefghigklmnoprst"));
-            ser.bare_item(key_ref("dict_key3"), integer(123456785686457));
+            ser.bare_item(key_ref("dict_key3"), integer(123_456_785_686_457));
             {
                 let mut ser = ser.inner_list(key_ref("dict_key4"));
-                ser.bare_item(string_ref("inner-list-member"));
-                ser.bare_item("inner-list-member".as_bytes());
-                ser.finish()
+                _ = ser.bare_item(string_ref("inner-list-member"));
+                _ = ser.bare_item("inner-list-member".as_bytes());
+                _ = ser
+                    .finish()
                     .parameter(key_ref("key"), token_ref("aW5uZXItbGlzdC1wYXJhbWV0ZXJz"));
             }
             ser.finish()

--- a/src/date.rs
+++ b/src/date.rs
@@ -27,11 +27,13 @@ impl Date {
     pub const UNIX_EPOCH: Self = Self::from_unix_seconds(Integer::ZERO);
 
     /// Returns the date as an integer number of seconds from the Unix epoch.
+    #[must_use]
     pub fn unix_seconds(&self) -> Integer {
         self.0
     }
 
     /// Creates a date from an integer number of seconds from the Unix epoch.
+    #[must_use]
     pub const fn from_unix_seconds(v: Integer) -> Self {
         Self(v)
     }

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -34,6 +34,7 @@ impl Integer {
     /// This method is intended to be called from `const` contexts in which the
     /// value is known to be valid. Use [`TryFrom::try_from`] for non-panicking
     /// conversions.
+    #[must_use]
     pub const fn constant(v: i64) -> Self {
         if v >= Self::MIN.0 && v <= Self::MAX.0 {
             Self(v)
@@ -131,6 +132,7 @@ impl_conversions! {
 /// This method is intended to be called from `const` contexts in which the
 /// value is known to be valid. Use [`TryFrom::try_from`] for non-panicking
 /// conversions.
+#[must_use]
 pub const fn integer(v: i64) -> Integer {
     Integer::constant(v)
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,8 +1,9 @@
-use std::borrow::Borrow;
-use std::fmt;
+use std::{borrow::Borrow, fmt};
 
-use crate::error::{Error, NonEmptyStringError};
-use crate::utils;
+use crate::{
+    error::{Error, NonEmptyStringError},
+    utils,
+};
 
 /// An owned structured field value [key].
 ///
@@ -57,6 +58,9 @@ impl KeyRef {
     const fn cast(v: &str) -> &Self;
 
     /// Creates a `&KeyRef` from a `&str`.
+    ///
+    /// # Errors
+    /// If the input string validation fails.
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(v: &str) -> Result<&Self, Error> {
         validate(v.as_bytes())?;
@@ -75,14 +79,19 @@ impl KeyRef {
     /// This method is intended to be called from `const` contexts in which the
     /// value is known to be valid. Use [`KeyRef::from_str`] for non-panicking
     /// conversions.
+    ///
+    /// # Errors
+    /// If the input string validation fails.
+    #[must_use]
     pub const fn constant(v: &str) -> &Self {
         match validate(v.as_bytes()) {
-            Ok(_) => Self::cast(v),
+            Ok(()) => Self::cast(v),
             Err(err) => panic!("{}", err.msg()),
         }
     }
 
     /// Returns the key as a `&str`.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -133,9 +142,12 @@ impl Key {
     /// Creates a `Key` from a `String`.
     ///
     /// Returns the original value if the conversion failed.
+    ///
+    /// # Errors
+    /// If the input string validation fails.
     pub fn from_string(v: String) -> Result<Self, (Error, String)> {
         match validate(v.as_bytes()) {
-            Ok(_) => Ok(Self(v)),
+            Ok(()) => Ok(Self(v)),
             Err(err) => Err((err.into(), v)),
         }
     }
@@ -148,6 +160,7 @@ impl Key {
 /// This method is intended to be called from `const` contexts in which the
 /// value is known to be valid. Use [`KeyRef::from_str`] for non-panicking
 /// conversions.
+#[must_use]
 pub const fn key_ref(v: &str) -> &KeyRef {
     KeyRef::constant(v)
 }

--- a/src/parsed.rs
+++ b/src/parsed.rs
@@ -2,7 +2,13 @@ use std::convert::Infallible;
 
 use indexmap::IndexMap;
 
-use crate::{visitor::*, BareItem, BareItemFromInput, Key, KeyRef};
+use crate::{
+    visitor::{
+        DictionaryVisitor, EntryVisitor, InnerListVisitor, ItemVisitor, ListVisitor,
+        ParameterVisitor,
+    },
+    BareItem, BareItemFromInput, Key, KeyRef,
+};
 
 /// An [item]-type structured field value.
 ///
@@ -105,6 +111,7 @@ pub struct InnerList {
 
 impl InnerList {
     /// Returns a new `InnerList` with empty `Parameters`.
+    #[must_use]
     pub fn new(items: Vec<Item>) -> Self {
         Self {
             items,
@@ -113,6 +120,7 @@ impl InnerList {
     }
 
     /// Returns a new `InnerList` with the given `Parameters`.
+    #[must_use]
     pub fn with_params(items: Vec<Item>, params: Parameters) -> Self {
         Self { items, params }
     }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,9 +1,8 @@
 use std::fmt::Write as _;
 
-use crate::utils;
 #[cfg(feature = "parsed-types")]
 use crate::{private::Sealed, Dictionary, Item, List};
-use crate::{Date, Decimal, Integer, KeyRef, RefBareItem, StringRef, TokenRef};
+use crate::{utils, Date, Decimal, Integer, KeyRef, RefBareItem, StringRef, TokenRef};
 
 /// Serializes a structured field value into a string.
 ///
@@ -187,8 +186,8 @@ impl Serializer {
             match c {
                 b'%' | b'"' | 0x00..=0x1f | 0x7f..=0xff => {
                     output.push('%');
-                    output.push(char::from_digit((c as u32 >> 4) & 0xf, 16).unwrap());
-                    output.push(char::from_digit(c as u32 & 0xf, 16).unwrap());
+                    output.push(char::from_digit((u32::from(c) >> 4) & 0xf, 16).unwrap());
+                    output.push(char::from_digit(u32::from(c) & 0xf, 16).unwrap());
                 }
                 _ => output.push(c as char),
             }

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,6 +1,8 @@
-use std::borrow::{Borrow, Cow};
-use std::fmt;
-use std::string::String as StdString;
+use std::{
+    borrow::{Borrow, Cow},
+    fmt,
+    string::String as StdString,
+};
 
 use crate::Error;
 
@@ -53,11 +55,15 @@ impl StringRef {
     const fn cast(v: &str) -> &Self;
 
     /// Creates an empty `&StringRef`.
+    #[must_use]
     pub const fn empty() -> &'static Self {
         Self::cast("")
     }
 
     /// Creates a `&StringRef` from a `&str`.
+    ///
+    /// # Errors
+    /// The error reports the cause of any failed string validation.
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(v: &str) -> Result<&Self, Error> {
         validate(v.as_bytes())?;
@@ -69,14 +75,16 @@ impl StringRef {
     /// This method is intended to be called from `const` contexts in which the
     /// value is known to be valid. Use [`StringRef::from_str`] for non-panicking
     /// conversions.
+    #[must_use]
     pub const fn constant(v: &str) -> &Self {
         match validate(v.as_bytes()) {
-            Ok(_) => Self::cast(v),
+            Ok(()) => Self::cast(v),
             Err(_) => panic!("invalid character for string"),
         }
     }
 
     /// Returns the string as a `&str`.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -127,9 +135,12 @@ impl String {
     /// Creates a `String` from a `std::string::String`.
     ///
     /// Returns the original value if the conversion failed.
+    ///
+    /// # Errors
+    /// The error reports any problems from failed validation.
     pub fn from_string(v: StdString) -> Result<Self, (Error, StdString)> {
         match validate(v.as_bytes()) {
-            Ok(_) => Ok(Self(v)),
+            Ok(()) => Ok(Self(v)),
             Err(err) => Err((err.into(), v)),
         }
     }
@@ -142,6 +153,7 @@ impl String {
 /// This method is intended to be called from `const` contexts in which the
 /// value is known to be valid. Use [`StringRef::from_str`] for non-panicking
 /// conversions.
+#[must_use]
 pub const fn string_ref(v: &str) -> &StringRef {
     StringRef::constant(v)
 }

--- a/src/test_decimal.rs
+++ b/src/test_decimal.rs
@@ -1,5 +1,8 @@
 use crate::{Decimal, Error, Integer};
 
+// Expect a floating point error less than the smallest allowed value of 0.001
+const ABSERR: f64 = 0.000_1_f64;
+
 #[test]
 fn test_display() {
     for (expected, input) in [
@@ -44,15 +47,13 @@ fn test_into_f64() {
         (-10.0, -10000),
         (-0.123, -123),
     ] {
-        assert_eq!(
-            expected,
-            f64::from(Decimal::from_integer_scaled_1000(input.into()))
+        assert!(
+            (expected - f64::from(Decimal::from_integer_scaled_1000(input.into()))).abs() < ABSERR
         );
     }
 
-    assert_eq!(-999_999_999_999.999, f64::from(Decimal::MIN));
-
-    assert_eq!(999_999_999_999.999, f64::from(Decimal::MAX));
+    assert!((-999_999_999_999.999 - f64::from(Decimal::MIN)).abs() < ABSERR);
+    assert!((999_999_999_999.999 - f64::from(Decimal::MAX)).abs() < ABSERR);
 }
 
 #[test]
@@ -61,6 +62,8 @@ fn test_try_from_f64() {
         (Err(Error::new("NaN")), f64::NAN),
         (Err(Error::out_of_range()), f64::INFINITY),
         (Err(Error::out_of_range()), f64::NEG_INFINITY),
+        (Err(Error::out_of_range()), 2_f64.powi(65)),
+        (Err(Error::out_of_range()), -(2_f64.powi(65))),
         (Err(Error::out_of_range()), -1_000_000_000_000.0),
         (Err(Error::out_of_range()), 1_000_000_000_000.0),
         (Ok(Decimal::MIN), -999_999_999_999.999),

--- a/src/test_integer.rs
+++ b/src/test_integer.rs
@@ -1,13 +1,13 @@
 use crate::{Error, Integer};
 
 #[test]
-#[should_panic]
+#[should_panic = "out of range"]
 fn test_constant_too_small() {
     let _ = Integer::constant(-1_000_000_000_000_000);
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "out of range"]
 fn test_constant_too_large() {
     let _ = Integer::constant(1_000_000_000_000_000);
 }

--- a/src/test_key.rs
+++ b/src/test_key.rs
@@ -1,19 +1,19 @@
 use crate::KeyRef;
 
 #[test]
-#[should_panic]
+#[should_panic = "cannot be empty"]
 fn test_constant_empty() {
     let _ = KeyRef::constant("");
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "invalid character"]
 fn test_constant_invalid_start_char() {
     let _ = KeyRef::constant("_key");
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "invalid character"]
 fn test_constant_invalid_inner_char() {
     let _ = KeyRef::constant("aND");
 }

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -437,7 +437,7 @@ fn parse_string() -> Result<(), Error> {
 
     assert_eq!(string_ref("test"), Parser::new(r#""test""#).parse_string()?);
     assert_eq!(
-        string_ref(r#"te\st"#),
+        string_ref("te\\st"),
         Parser::new(r#""te\\st""#).parse_string()?
     );
     assert_eq!(string_ref(""), Parser::new(r#""""#).parse_string()?);
@@ -561,7 +561,10 @@ fn parse_byte_sequence_errors() {
 #[test]
 fn parse_number_int() -> Result<(), Error> {
     let mut parser = Parser::new("-733333333332d.14");
-    assert_eq!(Num::Integer(integer(-733333333332)), parser.parse_number()?);
+    assert_eq!(
+        Num::Integer(integer(-733_333_333_332)),
+        parser.parse_number()?
+    );
     assert_eq!(parser.remaining(), b"d.14");
 
     assert_eq!(Num::Integer(integer(42)), Parser::new("42").parse_number()?);
@@ -576,21 +579,21 @@ fn parse_number_int() -> Result<(), Error> {
     assert_eq!(Num::Integer(integer(0)), Parser::new("0").parse_number()?);
     assert_eq!(Num::Integer(integer(0)), Parser::new("00").parse_number()?);
     assert_eq!(
-        Num::Integer(integer(123456789012345)),
+        Num::Integer(integer(123_456_789_012_345)),
         Parser::new("123456789012345").parse_number()?
     );
     assert_eq!(
-        Num::Integer(integer(-123456789012345)),
+        Num::Integer(integer(-123_456_789_012_345)),
         Parser::new("-123456789012345").parse_number()?
     );
     assert_eq!(Num::Integer(integer(2)), Parser::new("2,3").parse_number()?);
     assert_eq!(Num::Integer(integer(4)), Parser::new("4-2").parse_number()?);
     assert_eq!(
-        Num::Integer(integer(-999999999999999)),
+        Num::Integer(integer(-999_999_999_999_999)),
         Parser::new("-999999999999999").parse_number()?
     );
     assert_eq!(
-        Num::Integer(integer(999999999999999)),
+        Num::Integer(integer(999_999_999_999_999)),
         Parser::new("999999999999999").parse_number()?
     );
 
@@ -627,11 +630,11 @@ fn parse_number_decimal() -> Result<(), Error> {
         Parser::new("-2.14").parse_number()?
     );
     assert_eq!(
-        Num::Decimal(Decimal::try_from(123456789012.1)?),
+        Num::Decimal(Decimal::try_from(123_456_789_012.1)?),
         Parser::new("123456789012.1").parse_number()?
     );
     assert_eq!(
-        Num::Decimal(Decimal::try_from(1234567890.112)?),
+        Num::Decimal(Decimal::try_from(1_234_567_890.112)?),
         Parser::new("1234567890.112").parse_number()?
     );
 

--- a/src/test_ref_serializer.rs
+++ b/src/test_ref_serializer.rs
@@ -2,7 +2,6 @@ use std::borrow::BorrowMut;
 
 use crate::{
     key_ref, string_ref, token_ref, Decimal, DictSerializer, ItemSerializer, ListSerializer,
-    SFVResult,
 };
 
 #[test]
@@ -22,16 +21,19 @@ fn test_fast_serialize_item() {
 #[test]
 fn test_fast_serialize_list() {
     fn check(mut ser: ListSerializer<impl BorrowMut<String>>) {
-        ser.bare_item(token_ref("hello"))
+        _ = ser
+            .bare_item(token_ref("hello"))
             .parameter(key_ref("key1"), true)
             .parameter(key_ref("key2"), false);
 
         {
             let mut ser = ser.inner_list();
-            ser.bare_item(string_ref("some_string"));
-            ser.bare_item(12)
+            _ = ser.bare_item(string_ref("some_string"));
+            _ = ser
+                .bare_item(12)
                 .parameter(key_ref("inner-member-key"), true);
-            ser.finish()
+            _ = ser
+                .finish()
                 .parameter(key_ref("inner-list-param"), token_ref("*"));
         }
 
@@ -48,27 +50,29 @@ fn test_fast_serialize_list() {
 #[test]
 fn test_fast_serialize_dict() {
     fn check(mut ser: DictSerializer<impl BorrowMut<String>>) {
-        ser.bare_item(key_ref("member1"), token_ref("hello"))
+        _ = ser
+            .bare_item(key_ref("member1"), token_ref("hello"))
             .parameter(key_ref("key1"), true)
             .parameter(key_ref("key2"), false);
 
-        ser.bare_item(key_ref("member2"), true)
+        _ = ser
+            .bare_item(key_ref("member2"), true)
             .parameter(key_ref("key3"), Decimal::try_from(45.4586).unwrap())
             .parameter(key_ref("key4"), string_ref("str"));
 
         {
             let mut ser = ser.inner_list(key_ref("key5"));
-            ser.bare_item(45);
-            ser.bare_item(0);
+            _ = ser.bare_item(45);
+            _ = ser.bare_item(0);
         }
 
         ser.bare_item(key_ref("key6"), string_ref("foo"));
 
         {
             let mut ser = ser.inner_list(key_ref("key7"));
-            ser.bare_item("some_string".as_bytes());
-            ser.bare_item("other_string".as_bytes());
-            ser.finish().parameter(key_ref("lparam"), 10);
+            _ = ser.bare_item("some_string".as_bytes());
+            _ = ser.bare_item("other_string".as_bytes());
+            _ = ser.finish().parameter(key_ref("lparam"), 10);
         }
 
         ser.bare_item(key_ref("key8"), true);
@@ -99,7 +103,7 @@ fn test_serialize_empty() {
 
 // Regression test for https://github.com/undef1nd/sfv/issues/131.
 #[test]
-fn test_with_buffer_separator() -> SFVResult<()> {
+fn test_with_buffer_separator() {
     let mut output = String::from(" ");
     ListSerializer::with_buffer(&mut output).bare_item(1);
     assert_eq!(output, " 1");
@@ -107,6 +111,4 @@ fn test_with_buffer_separator() -> SFVResult<()> {
     let mut output = String::from(" ");
     DictSerializer::with_buffer(&mut output).bare_item(key_ref("key1"), 1);
     assert_eq!(output, " key1=1");
-
-    Ok(())
 }

--- a/src/test_serializer.rs
+++ b/src/test_serializer.rs
@@ -1,5 +1,6 @@
-use crate::serializer::Serializer;
-use crate::{integer, key_ref, string_ref, token_ref, Date, Decimal, Error};
+use crate::{
+    integer, key_ref, serializer::Serializer, string_ref, token_ref, Date, Decimal, Error,
+};
 #[cfg(feature = "parsed-types")]
 use crate::{BareItem, Dictionary, InnerList, Item, List, Parameters, SerializeValue};
 
@@ -34,7 +35,7 @@ fn serialize_value_list_mixed_members_with_params() -> Result<(), Error> {
     let inner_list_item1 = Item::with_params(string_ref("str1"), inner_list_item1_param);
     let inner_list_item2_param = Parameters::from_iter(vec![(
         key_ref("in2_p").to_owned(),
-        BareItem::String(string_ref(r#"valu\e"#).to_owned()),
+        BareItem::String(string_ref("valu\\e").to_owned()),
     )]);
     let inner_list_item2 = Item::with_params(token_ref("str2"), inner_list_item2_param);
     let inner_list_param = Parameters::from_iter(vec![(
@@ -115,7 +116,7 @@ fn serialize_integer() {
 #[test]
 fn serialize_decimal() -> Result<(), Error> {
     let mut buf = String::new();
-    Serializer::serialize_decimal(Decimal::try_from(-99.1346897)?, &mut buf);
+    Serializer::serialize_decimal(Decimal::try_from(-99.134_689_7)?, &mut buf);
     assert_eq!("-99.135", &buf);
 
     buf.clear();
@@ -123,7 +124,7 @@ fn serialize_decimal() -> Result<(), Error> {
     assert_eq!("-1.0", &buf);
 
     buf.clear();
-    Serializer::serialize_decimal(Decimal::try_from(-99.1346897)?, &mut buf);
+    Serializer::serialize_decimal(Decimal::try_from(-99.134_689_7)?, &mut buf);
     assert_eq!("-99.135", &buf);
 
     buf.clear();
@@ -143,11 +144,11 @@ fn serialize_decimal() -> Result<(), Error> {
     assert_eq!("-137.0", &buf);
 
     buf.clear();
-    Serializer::serialize_decimal(Decimal::try_from(137121212112.123)?, &mut buf);
+    Serializer::serialize_decimal(Decimal::try_from(137_121_212_112.123)?, &mut buf);
     assert_eq!("137121212112.123", &buf);
 
     buf.clear();
-    Serializer::serialize_decimal(Decimal::try_from(137121212112.1238)?, &mut buf);
+    Serializer::serialize_decimal(Decimal::try_from(137_121_212_112.123_8)?, &mut buf);
     assert_eq!("137121212112.124", &buf);
     Ok(())
 }
@@ -163,7 +164,7 @@ fn serialize_string() {
     assert_eq!(r#""hello \"name\"""#, &buf);
 
     buf.clear();
-    Serializer::serialize_string(string_ref(r#"something\nothing"#), &mut buf);
+    Serializer::serialize_string(string_ref("something\\nothing"), &mut buf);
     assert_eq!(r#""something\\nothing""#, &buf);
 
     buf.clear();

--- a/src/test_string.rs
+++ b/src/test_string.rs
@@ -1,7 +1,7 @@
 use crate::StringRef;
 
 #[test]
-#[should_panic]
+#[should_panic = "invalid character"]
 fn test_constant_invalid_char() {
     let _ = StringRef::constant("text \x00");
 }

--- a/src/test_token.rs
+++ b/src/test_token.rs
@@ -1,19 +1,19 @@
 use crate::TokenRef;
 
 #[test]
-#[should_panic]
+#[should_panic = "cannot be empty"]
 fn test_constant_empty() {
     let _ = TokenRef::constant("");
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "invalid character"]
 fn test_constant_invalid_start_char() {
     let _ = TokenRef::constant("#some");
 }
 
 #[test]
-#[should_panic]
+#[should_panic = "invalid character"]
 fn test_constant_invalid_inner_char() {
     let _ = TokenRef::constant("s ");
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,8 +1,9 @@
-use std::borrow::Borrow;
-use std::fmt;
+use std::{borrow::Borrow, fmt};
 
-use crate::error::{Error, NonEmptyStringError};
-use crate::utils;
+use crate::{
+    error::{Error, NonEmptyStringError},
+    utils,
+};
 
 /// An owned structured field value [token].
 ///
@@ -57,6 +58,9 @@ impl TokenRef {
     const fn cast(v: &str) -> &Self;
 
     /// Creates a `&TokenRef` from a `&str`.
+    ///
+    /// # Errors
+    /// The error result reports the reason for any failed validation.
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(v: &str) -> Result<&Self, Error> {
         validate(v.as_bytes())?;
@@ -75,14 +79,16 @@ impl TokenRef {
     /// This method is intended to be called from `const` contexts in which the
     /// value is known to be valid. Use [`TokenRef::from_str`] for non-panicking
     /// conversions.
+    #[must_use]
     pub const fn constant(v: &str) -> &Self {
         match validate(v.as_bytes()) {
-            Ok(_) => Self::cast(v),
+            Ok(()) => Self::cast(v),
             Err(err) => panic!("{}", err.msg()),
         }
     }
 
     /// Returns the token as a `&str`.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -133,9 +139,12 @@ impl Token {
     /// Creates a `Token` from a `String`.
     ///
     /// Returns the original value if the conversion failed.
+    ///
+    /// # Errors
+    /// The error result reports the reason for any failed validation.
     pub fn from_string(v: String) -> Result<Self, (Error, String)> {
         match validate(v.as_bytes()) {
-            Ok(_) => Ok(Self(v)),
+            Ok(()) => Ok(Self(v)),
             Err(err) => Err((err.into(), v)),
         }
     }
@@ -148,6 +157,7 @@ impl Token {
 /// This method is intended to be called from `const` contexts in which the
 /// value is known to be valid. Use [`TokenRef::from_str`] for non-panicking
 /// conversions.
+#[must_use]
 pub const fn token_ref(v: &str) -> &TokenRef {
     TokenRef::constant(v)
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -183,6 +183,9 @@ pub trait ParameterVisitor<'input> {
     /// values for a given parameter key must be overwritten by later ones.
     ///
     /// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html#parse-param>
+    ///
+    /// # Errors
+    /// The error result should reports the reason for any failed validation.
     fn parameter(
         &mut self,
         key: &'input KeyRef,
@@ -192,6 +195,9 @@ pub trait ParameterVisitor<'input> {
     /// Called after all parameters have been parsed.
     ///
     /// Parsing will be terminated early if an error is returned.
+    ///
+    /// # Errors
+    /// The error result should reports the reason for any failed validation.
     fn finish(self) -> Result<(), Self::Error>
     where
         Self: Sized,
@@ -217,6 +223,9 @@ pub trait ItemVisitor<'input> {
     /// for guidance on discarding parameters.
     ///
     /// Parsing will be terminated early if an error is returned.
+    ///
+    /// # Errors
+    /// The error result should reports the reason for any failed validation.
     fn bare_item<'pv>(
         self,
         bare_item: BareItemFromInput<'input>,
@@ -235,6 +244,9 @@ pub trait InnerListVisitor<'input> {
     /// The returned visitor is used to handle the bare item.
     ///
     /// Parsing will be terminated early if an error is returned.
+    ///
+    /// # Errors
+    /// The error result should reports the reason for any failed validation.
     fn item<'iv>(&mut self) -> Result<impl ItemVisitor<'iv>, Self::Error>;
 
     /// Called after all inner-list items have been parsed.
@@ -244,6 +256,9 @@ pub trait InnerListVisitor<'input> {
     /// for guidance on discarding parameters.
     ///
     /// Parsing will be terminated early if an error is returned.
+    ///
+    /// # Errors
+    /// The error result should reports the reason for any failed validation.
     fn finish<'pv>(self) -> Result<impl ParameterVisitor<'pv>, Self::Error>;
 }
 
@@ -256,6 +271,9 @@ pub trait EntryVisitor<'input>: ItemVisitor<'input> {
     /// The returned visitor is used to handle the inner list.
     ///
     /// Parsing will be terminated early if an error is returned.
+    ///
+    /// # Errors
+    /// The error result should reports the reason for any failed validation.
     fn inner_list<'ilv>(self) -> Result<impl InnerListVisitor<'ilv>, Self::Error>;
 }
 
@@ -285,6 +303,9 @@ pub trait DictionaryVisitor<'input> {
     /// ones.
     ///
     /// [RFC 9651]: <https://httpwg.org/specs/rfc9651.html#parse-dictionary>
+    ///
+    /// # Errors
+    /// The error result should reports the reason for any failed validation.
     fn entry<'dv, 'ev>(
         &'dv mut self,
         key: &'input KeyRef,
@@ -308,6 +329,9 @@ pub trait ListVisitor<'input> {
     /// The returned visitor is used to handle the entry.
     ///
     /// Parsing will be terminated early if an error is returned.
+    ///
+    /// # Errors
+    /// The error result should reports the reason for any failed validation.
     fn entry<'ev>(&mut self) -> Result<impl EntryVisitor<'ev>, Self::Error>;
 }
 

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -1,6 +1,4 @@
-use std::error::Error;
-use std::path::Path;
-use std::{env, fmt, fs, io};
+use std::{env, error::Error, fmt, fs, io, path::Path};
 
 use serde::Deserialize;
 use sfv::{
@@ -102,7 +100,7 @@ impl TestCase for ParseTestData {
                     match test_case.data.canonical {
                         // If the canonical field is omitted, the canonical form is the input.
                         None => {
-                            assert_eq!(serialized.expect("serialization should succeed"), input)
+                            assert_eq!(serialized.expect("serialization should succeed"), input);
                         }
                         Some(ref canonical) => {
                             // If the canonical field is an empty list, the serialization
@@ -122,6 +120,7 @@ impl TestCase for ParseTestData {
             }
         }
 
+        #[allow(clippy::redundant_closure_for_method_calls)] // HRTB issue
         match self.data.header_type {
             ExpectedHeaderType::Item(ref mut expected) => {
                 let expected = expected.take();
@@ -153,7 +152,7 @@ impl TestCase for TestData {
                                 .canonical
                                 .as_ref()
                                 .expect("canonical serialization should be present")[0]
-                        )
+                        );
                     }
                     None => assert!(test_case.must_fail),
                 },
@@ -164,15 +163,15 @@ impl TestCase for TestData {
         match self.header_type {
             ExpectedHeaderType::Item(ref mut expected) => {
                 let expected = expected.take();
-                check(&self, expected)
+                check(&self, expected);
             }
             ExpectedHeaderType::List(ref mut expected) => {
                 let expected = expected.take();
-                check(&self, expected)
+                check(&self, expected);
             }
             ExpectedHeaderType::Dictionary(ref mut expected) => {
                 let expected = expected.take();
-                check(&self, expected)
+                check(&self, expected);
             }
         }
     }


### PR DESCRIPTION
These were not uniformly easy.  There are a couple of cases where the public API changes slightly, so this should be a new dot release.

Those changes are mostly through the inclusion of `#[must_use]` in a bunch of places. Using code will then get warnings when they throw values away.

The main problem I found there was that the serializer code relied on a Drop implementation in a couple of places.  I personally don't like that very much, so I added `#[must_use]` anyway.  Using code probably isn't exposed to this detail, even if they using custom serialization arrangements, as it was only test code that had to add a bunch of useless bindings to deal with this.  Still, this is worth noting.

This does not enable `clippy::pedantic`, but that could be done after these changes land.