### PR TITLE
Remove unnecessary lifetime constraint from parse_dictionary_with_visitor

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -120,9 +120,9 @@ assert_eq!(
     ///
     /// # Errors
     /// When the parsing process is unsuccessful, including any error raised by a visitor.
-    pub fn parse_dictionary_with_visitor<'v: 'a>(
+    pub fn parse_dictionary_with_visitor(
         self,
-        visitor: &'v mut (impl ?Sized + DictionaryVisitor<'a>),
+        visitor: &mut (impl ?Sized + DictionaryVisitor<'a>),
     ) -> SFVResult<()> {
         // https://httpwg.org/specs/rfc9651.html#parse-dictionary
         self.parse(move |parser| {

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -1168,6 +1168,8 @@ fn complex_list_visitor() {
     assert_eq!(list, expected);
 }
 
+// Regression test for https://github.com/undef1nd/sfv/issues/194.
+// This test does not compile without the associated fix.
 #[test]
 fn parse_dictionary_lifetime() -> Result<(), Error> {
     struct Visitor<'input>(Option<&'input KeyRef>);
@@ -1189,7 +1191,6 @@ fn parse_dictionary_lifetime() -> Result<(), Error> {
 
     let mut visitor = Visitor(None);
     Parser::new("a=1").parse_dictionary_with_visitor(&mut visitor)?;
-    // FIXME: cannot borrow `visitor.0` as immutable because it is also borrowed as mutable
     assert_eq!(visitor.0.as_deref(), Some(key_ref("a")));
     Ok(())
 }


### PR DESCRIPTION
Fixes #194