### PR TITLE
Use 'de as input lifetime across all visitor usage

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::{
 #[cfg(feature = "parsed-types")]
 use crate::{Dictionary, Item, List};
 
-fn parse_item<'a>(parser: &mut Parser<'a>, visitor: impl ItemVisitor<'a>) -> SFVResult<()> {
+fn parse_item<'de>(parser: &mut Parser<'de>, visitor: impl ItemVisitor<'de>) -> SFVResult<()> {
     // https://httpwg.org/specs/rfc9651.html#parse-item
     let param_visitor = visitor
         .bare_item(parser.parse_bare_item()?)
@@ -20,9 +20,9 @@ fn parse_item<'a>(parser: &mut Parser<'a>, visitor: impl ItemVisitor<'a>) -> SFV
     parser.parse_parameters(param_visitor)
 }
 
-fn parse_comma_separated<'a>(
-    parser: &mut Parser<'a>,
-    mut parse_member: impl FnMut(&mut Parser<'a>) -> SFVResult<()>,
+fn parse_comma_separated<'de>(
+    parser: &mut Parser<'de>,
+    mut parse_member: impl FnMut(&mut Parser<'de>) -> SFVResult<()>,
 ) -> SFVResult<()> {
     while parser.peek().is_some() {
         parse_member(parser)?;
@@ -55,15 +55,15 @@ fn parse_comma_separated<'a>(
 }
 
 /// Exposes methods for parsing input into a structured field value.
-pub struct Parser<'a> {
-    input: &'a [u8],
+pub struct Parser<'de> {
+    input: &'de [u8],
     index: usize,
     version: Version,
 }
 
-impl<'a> Parser<'a> {
+impl<'de> Parser<'de> {
     /// Creates a parser from the given input with [`Version::Rfc9651`].
-    pub fn new(input: &'a (impl ?Sized + AsRef<[u8]>)) -> Self {
+    pub fn new(input: &'de (impl ?Sized + AsRef<[u8]>)) -> Self {
         Self {
             input: input.as_ref(),
             index: 0,
@@ -119,7 +119,7 @@ assert_eq!(
     /// When the parsing process is unsuccessful, including any error raised by a visitor.
     pub fn parse_dictionary_with_visitor(
         self,
-        visitor: &mut (impl ?Sized + DictionaryVisitor<'a>),
+        visitor: &mut (impl ?Sized + DictionaryVisitor<'de>),
     ) -> SFVResult<()> {
         // https://httpwg.org/specs/rfc9651.html#parse-dictionary
         self.parse(move |parser| {
@@ -181,7 +181,7 @@ assert_eq!(
     /// When the parsing process is unsuccessful, including any error raised by a visitor.
     pub fn parse_list_with_visitor(
         self,
-        visitor: &mut (impl ?Sized + ListVisitor<'a>),
+        visitor: &mut (impl ?Sized + ListVisitor<'de>),
     ) -> SFVResult<()> {
         // https://httpwg.org/specs/rfc9651.html#parse-list
         self.parse(|parser| {
@@ -207,7 +207,7 @@ assert_eq!(
     ///
     /// # Errors
     /// When the parsing process is unsuccessful, including any error raised by a visitor.
-    pub fn parse_item_with_visitor(self, visitor: impl ItemVisitor<'a>) -> SFVResult<()> {
+    pub fn parse_item_with_visitor(self, visitor: impl ItemVisitor<'de>) -> SFVResult<()> {
         self.parse(|parser| parse_item(parser, visitor))
     }
 
@@ -241,7 +241,7 @@ assert_eq!(
         }
     }
 
-    fn parse_list_entry(&mut self, visitor: impl EntryVisitor<'a>) -> SFVResult<()> {
+    fn parse_list_entry(&mut self, visitor: impl EntryVisitor<'de>) -> SFVResult<()> {
         // https://httpwg.org/specs/rfc9651.html#parse-item-or-list
         // ListEntry represents a tuple (item_or_inner_list, parameters)
 
@@ -253,7 +253,7 @@ assert_eq!(
 
     pub(crate) fn parse_inner_list(
         &mut self,
-        mut visitor: impl InnerListVisitor<'a>,
+        mut visitor: impl InnerListVisitor<'de>,
     ) -> SFVResult<()> {
         // https://httpwg.org/specs/rfc9651.html#parse-innerlist
 
@@ -284,7 +284,7 @@ assert_eq!(
         self.error("unterminated inner list")
     }
 
-    pub(crate) fn parse_bare_item(&mut self) -> SFVResult<BareItemFromInput<'a>> {
+    pub(crate) fn parse_bare_item(&mut self) -> SFVResult<BareItemFromInput<'de>> {
         // https://httpwg.org/specs/rfc9651.html#parse-bare-item
 
         match self.peek() {
@@ -328,7 +328,7 @@ assert_eq!(
         }
     }
 
-    pub(crate) fn parse_string(&mut self) -> SFVResult<Cow<'a, StringRef>> {
+    pub(crate) fn parse_string(&mut self) -> SFVResult<Cow<'de, StringRef>> {
         // https://httpwg.org/specs/rfc9651.html#parse-string
 
         if self.peek() != Some(b'"') {
@@ -387,7 +387,7 @@ assert_eq!(
         &mut self,
         is_allowed_start_char: impl FnOnce(u8) -> bool,
         is_allowed_inner_char: impl Fn(u8) -> bool,
-    ) -> Option<&'a str> {
+    ) -> Option<&'de str> {
         let start = self.index;
 
         match self.peek() {
@@ -409,7 +409,7 @@ assert_eq!(
         }
     }
 
-    pub(crate) fn parse_token(&mut self) -> SFVResult<&'a TokenRef> {
+    pub(crate) fn parse_token(&mut self) -> SFVResult<&'de TokenRef> {
         // https://httpwg.org/specs/9651.html#parse-token
 
         match self.parse_non_empty_str(
@@ -553,7 +553,7 @@ assert_eq!(
         }
     }
 
-    pub(crate) fn parse_display_string(&mut self) -> SFVResult<Cow<'a, str>> {
+    pub(crate) fn parse_display_string(&mut self) -> SFVResult<Cow<'de, str>> {
         // https://httpwg.org/specs/rfc9651.html#parse-display
 
         if self.peek() != Some(b'%') {
@@ -637,7 +637,7 @@ assert_eq!(
 
     pub(crate) fn parse_parameters(
         &mut self,
-        mut visitor: impl ParameterVisitor<'a>,
+        mut visitor: impl ParameterVisitor<'de>,
     ) -> SFVResult<()> {
         // https://httpwg.org/specs/rfc9651.html#parse-param
 
@@ -662,7 +662,7 @@ assert_eq!(
         visitor.finish().map_err(Error::custom)
     }
 
-    pub(crate) fn parse_key(&mut self) -> SFVResult<&'a KeyRef> {
+    pub(crate) fn parse_key(&mut self) -> SFVResult<&'de KeyRef> {
         // https://httpwg.org/specs/rfc9651.html#parse-key
 
         match self.parse_non_empty_str(

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -18,14 +18,14 @@ relevant state in its fields, before using that state to perform the operation
 # use sfv::visitor::{Ignored, ItemVisitor, ParameterVisitor};
 # use sfv::{BareItemFromInput, TokenRef};
 # fn main() -> Result<(), sfv::Error> {
-struct Visitor<'a> {
-    token: Option<&'a TokenRef>,
+struct Visitor<'de> {
+    token: Option<&'de TokenRef>,
 }
 
-impl<'a> ItemVisitor<'a> for &mut Visitor<'a> {
+impl<'de> ItemVisitor<'de> for &mut Visitor<'de> {
   type Error = std::convert::Infallible;
 
-  fn bare_item(self, bare_item: BareItemFromInput<'a>) -> Result<impl ParameterVisitor<'a>, Self::Error> {
+  fn bare_item(self, bare_item: BareItemFromInput<'de>) -> Result<impl ParameterVisitor<'de>, Self::Error> {
       self.token =
           if let BareItemFromInput::Token(token) = bare_item {
               Some(token)
@@ -87,13 +87,13 @@ struct CoordVisitor<'a> {
     coord: &'a mut i64,
 }
 
-impl<'input> DictionaryVisitor<'input> for Point {
+impl<'de> DictionaryVisitor<'de> for Point {
     type Error = std::convert::Infallible;
 
     fn entry(
         &mut self,
-        key: &'input KeyRef,
-    ) -> Result<impl EntryVisitor<'input>, Self::Error>
+        key: &'de KeyRef,
+    ) -> Result<impl EntryVisitor<'de>, Self::Error>
     {
         let coord = match key.as_str() {
             "x" => &mut self.x,
@@ -119,13 +119,13 @@ impl std::fmt::Display for NotAnInteger {
 
 impl std::error::Error for NotAnInteger {}
 
-impl<'input> ItemVisitor<'input> for CoordVisitor<'_> {
+impl<'de> ItemVisitor<'de> for CoordVisitor<'_> {
     type Error = NotAnInteger;
 
     fn bare_item(
         self,
-        bare_item: BareItemFromInput<'input>,
-    ) -> Result<impl ParameterVisitor<'input>, Self::Error> {
+        bare_item: BareItemFromInput<'de>,
+    ) -> Result<impl ParameterVisitor<'de>, Self::Error> {
         if let BareItemFromInput::Integer(v) = bare_item {
             *self.coord = i64::from(v);
             // Ignore the item's parameters by returning `Ignored`. The
@@ -141,8 +141,8 @@ impl<'input> ItemVisitor<'input> for CoordVisitor<'_> {
     }
 }
 
-impl<'input> EntryVisitor<'input> for CoordVisitor<'_> {
-    fn inner_list(self) -> Result<impl InnerListVisitor<'input>, Self::Error> {
+impl<'de> EntryVisitor<'de> for CoordVisitor<'_> {
+    fn inner_list(self) -> Result<impl InnerListVisitor<'de>, Self::Error> {
         // Use `Never` to enforce at the type level that this method will only
         // return `Err`, as our coordinate must be a single integer, not an
         // inner list.
@@ -165,8 +165,8 @@ use crate::{BareItemFromInput, KeyRef};
 
 /// A visitor whose methods are called during parameter parsing.
 ///
-/// The lifetime `'input` is the lifetime of the input.
-pub trait ParameterVisitor<'input> {
+/// The lifetime `'de` is the lifetime of the input.
+pub trait ParameterVisitor<'de> {
     /// The error type that can be returned if some error occurs during parsing.
     type Error: Error;
 
@@ -186,8 +186,8 @@ pub trait ParameterVisitor<'input> {
     /// The error result should report the reason for any failed validation.
     fn parameter(
         &mut self,
-        key: &'input KeyRef,
-        value: BareItemFromInput<'input>,
+        key: &'de KeyRef,
+        value: BareItemFromInput<'de>,
     ) -> Result<(), Self::Error>;
 
     /// Called after all parameters have been parsed.
@@ -206,11 +206,11 @@ pub trait ParameterVisitor<'input> {
 
 /// A visitor whose methods are called during item parsing.
 ///
-/// The lifetime `'input` is the lifetime of the input.
+/// The lifetime `'de` is the lifetime of the input.
 ///
 /// Use this trait with
 /// [`Parser::parse_item_with_visitor`][crate::Parser::parse_item_with_visitor].
-pub trait ItemVisitor<'input> {
+pub trait ItemVisitor<'de> {
     /// The error type that can be returned if some error occurs during parsing.
     type Error: Error;
 
@@ -226,14 +226,14 @@ pub trait ItemVisitor<'input> {
     /// The error result should report the reason for any failed validation.
     fn bare_item(
         self,
-        bare_item: BareItemFromInput<'input>,
-    ) -> Result<impl ParameterVisitor<'input>, Self::Error>;
+        bare_item: BareItemFromInput<'de>,
+    ) -> Result<impl ParameterVisitor<'de>, Self::Error>;
 }
 
 /// A visitor whose methods are called during inner-list parsing.
 ///
-/// The lifetime `'input` is the lifetime of the input.
-pub trait InnerListVisitor<'input> {
+/// The lifetime `'de` is the lifetime of the input.
+pub trait InnerListVisitor<'de> {
     /// The error type that can be returned if some error occurs during parsing.
     type Error: Error;
 
@@ -245,7 +245,7 @@ pub trait InnerListVisitor<'input> {
     ///
     /// # Errors
     /// The error result should report the reason for any failed validation.
-    fn item(&mut self) -> Result<impl ItemVisitor<'input>, Self::Error>;
+    fn item(&mut self) -> Result<impl ItemVisitor<'de>, Self::Error>;
 
     /// Called after all inner-list items have been parsed.
     ///
@@ -257,13 +257,13 @@ pub trait InnerListVisitor<'input> {
     ///
     /// # Errors
     /// The error result should report the reason for any failed validation.
-    fn finish(self) -> Result<impl ParameterVisitor<'input>, Self::Error>;
+    fn finish(self) -> Result<impl ParameterVisitor<'de>, Self::Error>;
 }
 
 /// A visitor whose methods are called during entry parsing.
 ///
-/// The lifetime `'input` is the lifetime of the input.
-pub trait EntryVisitor<'input>: ItemVisitor<'input> {
+/// The lifetime `'de` is the lifetime of the input.
+pub trait EntryVisitor<'de>: ItemVisitor<'de> {
     /// Called before an inner list has been parsed.
     ///
     /// The returned visitor is used to handle the inner list.
@@ -272,16 +272,16 @@ pub trait EntryVisitor<'input>: ItemVisitor<'input> {
     ///
     /// # Errors
     /// The error result should report the reason for any failed validation.
-    fn inner_list(self) -> Result<impl InnerListVisitor<'input>, Self::Error>;
+    fn inner_list(self) -> Result<impl InnerListVisitor<'de>, Self::Error>;
 }
 
 /// A visitor whose methods are called during dictionary parsing.
 ///
-/// The lifetime `'input` is the lifetime of the input.
+/// The lifetime `'de` is the lifetime of the input.
 ///
 /// Use this trait with
 /// [`Parser::parse_dictionary_with_visitor`][crate::Parser::parse_dictionary_with_visitor].
-pub trait DictionaryVisitor<'input> {
+pub trait DictionaryVisitor<'de> {
     /// The error type that can be returned if some error occurs during parsing.
     type Error: Error;
 
@@ -304,16 +304,16 @@ pub trait DictionaryVisitor<'input> {
     ///
     /// # Errors
     /// The error result should report the reason for any failed validation.
-    fn entry(&mut self, key: &'input KeyRef) -> Result<impl EntryVisitor<'input>, Self::Error>;
+    fn entry(&mut self, key: &'de KeyRef) -> Result<impl EntryVisitor<'de>, Self::Error>;
 }
 
 /// A visitor whose methods are called during list parsing.
 ///
-/// The lifetime `'input` is the lifetime of the input.
+/// The lifetime `'de` is the lifetime of the input.
 ///
 /// Use this trait with
 /// [`Parser::parse_list_with_visitor`][crate::Parser::parse_list_with_visitor].
-pub trait ListVisitor<'input> {
+pub trait ListVisitor<'de> {
     /// The error type that can be returned if some error occurs during parsing.
     type Error: Error;
 
@@ -325,7 +325,7 @@ pub trait ListVisitor<'input> {
     ///
     /// # Errors
     /// The error result should report the reason for any failed validation.
-    fn entry(&mut self) -> Result<impl EntryVisitor<'input>, Self::Error>;
+    fn entry(&mut self) -> Result<impl EntryVisitor<'de>, Self::Error>;
 }
 
 /// A visitor that can be used to silently discard structured-field parts.
@@ -339,70 +339,70 @@ pub trait ListVisitor<'input> {
 #[derive(Default)]
 pub struct Ignored;
 
-impl<'input> ParameterVisitor<'input> for Ignored {
+impl<'de> ParameterVisitor<'de> for Ignored {
     type Error = Infallible;
 
     fn parameter(
         &mut self,
-        _key: &'input KeyRef,
-        _value: BareItemFromInput<'input>,
+        _key: &'de KeyRef,
+        _value: BareItemFromInput<'de>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
-impl<'input> ItemVisitor<'input> for Ignored {
+impl<'de> ItemVisitor<'de> for Ignored {
     type Error = Infallible;
 
     fn bare_item(
         self,
-        _bare_item: BareItemFromInput<'input>,
-    ) -> Result<impl ParameterVisitor<'input>, Self::Error> {
+        _bare_item: BareItemFromInput<'de>,
+    ) -> Result<impl ParameterVisitor<'de>, Self::Error> {
         Ok(Ignored)
     }
 }
 
-impl<'input> EntryVisitor<'input> for Ignored {
-    fn inner_list(self) -> Result<impl InnerListVisitor<'input>, Self::Error> {
+impl<'de> EntryVisitor<'de> for Ignored {
+    fn inner_list(self) -> Result<impl InnerListVisitor<'de>, Self::Error> {
         Ok(Ignored)
     }
 }
 
-impl<'input> InnerListVisitor<'input> for Ignored {
+impl<'de> InnerListVisitor<'de> for Ignored {
     type Error = Infallible;
 
-    fn item(&mut self) -> Result<impl ItemVisitor<'input>, Self::Error> {
+    fn item(&mut self) -> Result<impl ItemVisitor<'de>, Self::Error> {
         Ok(Ignored)
     }
 
-    fn finish(self) -> Result<impl ParameterVisitor<'input>, Self::Error> {
+    fn finish(self) -> Result<impl ParameterVisitor<'de>, Self::Error> {
         Ok(Ignored)
     }
 }
 
-impl<'input> DictionaryVisitor<'input> for Ignored {
+impl<'de> DictionaryVisitor<'de> for Ignored {
     type Error = Infallible;
 
-    fn entry(&mut self, _key: &'input KeyRef) -> Result<impl EntryVisitor<'input>, Self::Error> {
+    fn entry(&mut self, _key: &'de KeyRef) -> Result<impl EntryVisitor<'de>, Self::Error> {
         Ok(Ignored)
     }
 }
 
-impl<'input> ListVisitor<'input> for Ignored {
+impl<'de> ListVisitor<'de> for Ignored {
     type Error = Infallible;
 
-    fn entry(&mut self) -> Result<impl EntryVisitor<'input>, Self::Error> {
+    fn entry(&mut self) -> Result<impl EntryVisitor<'de>, Self::Error> {
         Ok(Ignored)
     }
 }
 
-impl<'input, V: ParameterVisitor<'input>> ParameterVisitor<'input> for Option<V> {
+impl<'de, V: ParameterVisitor<'de>> ParameterVisitor<'de> for Option<V> {
     type Error = V::Error;
 
     fn parameter(
         &mut self,
-        key: &'input KeyRef,
-        value: BareItemFromInput<'input>,
+        key: &'de KeyRef,
+        value: BareItemFromInput<'de>,
     ) -> Result<(), Self::Error> {
         match self {
             None => Ok(()),
@@ -411,13 +411,13 @@ impl<'input, V: ParameterVisitor<'input>> ParameterVisitor<'input> for Option<V>
     }
 }
 
-impl<'input, V: ItemVisitor<'input>> ItemVisitor<'input> for Option<V> {
+impl<'de, V: ItemVisitor<'de>> ItemVisitor<'de> for Option<V> {
     type Error = V::Error;
 
     fn bare_item(
         self,
-        bare_item: BareItemFromInput<'input>,
-    ) -> Result<impl ParameterVisitor<'input>, Self::Error> {
+        bare_item: BareItemFromInput<'de>,
+    ) -> Result<impl ParameterVisitor<'de>, Self::Error> {
         match self {
             None => Ok(None),
             Some(visitor) => visitor.bare_item(bare_item).map(Some),
@@ -425,8 +425,8 @@ impl<'input, V: ItemVisitor<'input>> ItemVisitor<'input> for Option<V> {
     }
 }
 
-impl<'input, V: EntryVisitor<'input>> EntryVisitor<'input> for Option<V> {
-    fn inner_list(self) -> Result<impl InnerListVisitor<'input>, Self::Error> {
+impl<'de, V: EntryVisitor<'de>> EntryVisitor<'de> for Option<V> {
+    fn inner_list(self) -> Result<impl InnerListVisitor<'de>, Self::Error> {
         match self {
             None => Ok(None),
             Some(visitor) => visitor.inner_list().map(Some),
@@ -434,17 +434,17 @@ impl<'input, V: EntryVisitor<'input>> EntryVisitor<'input> for Option<V> {
     }
 }
 
-impl<'input, V: InnerListVisitor<'input>> InnerListVisitor<'input> for Option<V> {
+impl<'de, V: InnerListVisitor<'de>> InnerListVisitor<'de> for Option<V> {
     type Error = V::Error;
 
-    fn item(&mut self) -> Result<impl ItemVisitor<'input>, Self::Error> {
+    fn item(&mut self) -> Result<impl ItemVisitor<'de>, Self::Error> {
         match self {
             None => Ok(None),
             Some(visitor) => visitor.item().map(Some),
         }
     }
 
-    fn finish(self) -> Result<impl ParameterVisitor<'input>, Self::Error> {
+    fn finish(self) -> Result<impl ParameterVisitor<'de>, Self::Error> {
         match self {
             None => Ok(None),
             Some(visitor) => visitor.finish().map(Some),
@@ -460,59 +460,59 @@ impl<'input, V: InnerListVisitor<'input>> InnerListVisitor<'input> for Option<V>
 #[derive(Clone, Copy)]
 pub enum Never {}
 
-impl<'input> ParameterVisitor<'input> for Never {
+impl<'de> ParameterVisitor<'de> for Never {
     type Error = Infallible;
 
     fn parameter(
         &mut self,
-        _key: &'input KeyRef,
-        _value: BareItemFromInput<'input>,
+        _key: &'de KeyRef,
+        _value: BareItemFromInput<'de>,
     ) -> Result<(), Self::Error> {
         match *self {}
     }
 }
 
-impl<'input> ItemVisitor<'input> for Never {
+impl<'de> ItemVisitor<'de> for Never {
     type Error = Infallible;
 
     fn bare_item(
         self,
-        _bare_item: BareItemFromInput<'input>,
-    ) -> Result<impl ParameterVisitor<'input>, Self::Error> {
+        _bare_item: BareItemFromInput<'de>,
+    ) -> Result<impl ParameterVisitor<'de>, Self::Error> {
         Ok(self)
     }
 }
 
-impl<'input> EntryVisitor<'input> for Never {
-    fn inner_list(self) -> Result<impl InnerListVisitor<'input>, Self::Error> {
+impl<'de> EntryVisitor<'de> for Never {
+    fn inner_list(self) -> Result<impl InnerListVisitor<'de>, Self::Error> {
         Ok(self)
     }
 }
 
-impl<'input> InnerListVisitor<'input> for Never {
+impl<'de> InnerListVisitor<'de> for Never {
     type Error = Infallible;
 
-    fn item(&mut self) -> Result<impl ItemVisitor<'input>, Self::Error> {
+    fn item(&mut self) -> Result<impl ItemVisitor<'de>, Self::Error> {
         Ok(*self)
     }
 
-    fn finish(self) -> Result<impl ParameterVisitor<'input>, Self::Error> {
+    fn finish(self) -> Result<impl ParameterVisitor<'de>, Self::Error> {
         Ok(self)
     }
 }
 
-impl<'input> DictionaryVisitor<'input> for Never {
+impl<'de> DictionaryVisitor<'de> for Never {
     type Error = Infallible;
 
-    fn entry(&mut self, _key: &'input KeyRef) -> Result<impl EntryVisitor<'input>, Self::Error> {
+    fn entry(&mut self, _key: &'de KeyRef) -> Result<impl EntryVisitor<'de>, Self::Error> {
         Ok(*self)
     }
 }
 
-impl<'input> ListVisitor<'input> for Never {
+impl<'de> ListVisitor<'de> for Never {
     type Error = Infallible;
 
-    fn entry(&mut self) -> Result<impl EntryVisitor<'input>, Self::Error> {
+    fn entry(&mut self) -> Result<impl EntryVisitor<'de>, Self::Error> {
         Ok(*self)
     }
 }

--- a/tests/specification_tests.rs
+++ b/tests/specification_tests.rs
@@ -70,7 +70,7 @@ type ExpectedList = Vec<ExpectedListEntry>;
 
 type ExpectedDict = Vec<(String, ExpectedListEntry)>;
 
-trait TestCase: for<'a> Deserialize<'a> {
+trait TestCase: for<'de> Deserialize<'de> {
     fn run(self);
 }
 
@@ -78,7 +78,7 @@ impl TestCase for ParseTestData {
     fn run(mut self) {
         fn check<T: PartialEq + fmt::Debug + SerializeValue>(
             test_case: &ParseTestData,
-            parse: impl for<'a> FnOnce(Parser<'a>) -> Result<T, sfv::Error>,
+            parse: impl for<'de> FnOnce(Parser<'de>) -> Result<T, sfv::Error>,
             expected: Option<impl Build<T>>,
         ) {
             println!("- {}", test_case.data.name);


### PR DESCRIPTION
This is easier to understand than the current mixture of `'a` and `'input`, is shorter than `'input`, and has precedent in serde.

This has no behavioral changes -- it's just a renaming for documentation purposes.