### PR TITLE
Use enum for internal representation of errors

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -102,7 +102,7 @@ macro_rules! impl_try_from_integer {
 
                 fn try_from(v: $from) -> Result<Decimal, Error> {
                     match v.checked_mul(1000) {
-                        None => Err(error::Repr::OutOfRange)?,
+                        None => Err(error::Repr::OutOfRange.into()),
                         Some(v) => Integer::try_from(v).map(Decimal),
                     }
                 }
@@ -159,7 +159,7 @@ impl TryFrom<f64> for Decimal {
 
     fn try_from(v: f64) -> Result<Decimal, Error> {
         if v.is_nan() {
-            Err(error::Repr::NaN)?;
+            return Err(error::Repr::NaN.into());
         }
 
         let v = (v * 1000.0).round_ties_even();

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{Error, Integer};
+use crate::{error, Error, Integer};
 
 /// A structured field value [decimal].
 ///
@@ -102,7 +102,7 @@ macro_rules! impl_try_from_integer {
 
                 fn try_from(v: $from) -> Result<Decimal, Error> {
                     match v.checked_mul(1000) {
-                        None => Err(Error::out_of_range()),
+                        None => Err(error::Repr::OutOfRange)?,
                         Some(v) => Integer::try_from(v).map(Decimal),
                     }
                 }
@@ -159,7 +159,7 @@ impl TryFrom<f64> for Decimal {
 
     fn try_from(v: f64) -> Result<Decimal, Error> {
         if v.is_nan() {
-            return Err(Error::new("NaN"));
+            Err(error::Repr::NaN)?;
         }
 
         let v = (v * 1000.0).round_ties_even();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,132 @@
-use std::borrow::Cow;
 use std::fmt;
+
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub(crate) enum Repr {
+    Visit(Box<str>),
+
+    OutOfRange,
+    NaN,
+
+    Empty,
+    InvalidCharacter(usize),
+
+    TrailingCharactersAfterMember(usize),
+    TrailingComma(usize),
+    TrailingCharactersAfterParsedValue(usize),
+
+    ExpectedStartOfInnerList(usize),
+    ExpectedInnerListDelimiter(usize),
+    UnterminatedInnerList(usize),
+
+    ExpectedStartOfBareItem(usize),
+
+    ExpectedStartOfBoolean(usize),
+    ExpectedBoolean(usize),
+
+    ExpectedStartOfString(usize),
+    InvalidStringCharacter(usize),
+    UnterminatedString(usize),
+
+    UnterminatedEscapeSequence(usize),
+    InvalidEscapeSequence(usize),
+
+    ExpectedStartOfToken(usize),
+
+    ExpectedStartOfByteSequence(usize),
+    UnterminatedByteSequence(usize),
+    InvalidByteSequence(usize),
+
+    ExpectedDigit(usize),
+    TooManyDigits(usize),
+    TooManyDigitsBeforeDecimalPoint(usize),
+    TooManyDigitsAfterDecimalPoint(usize),
+    TrailingDecimalPoint(usize),
+
+    ExpectedStartOfDate(usize),
+    Rfc8941Date(usize),
+    NonIntegerDate(usize),
+
+    ExpectedStartOfDisplayString(usize),
+    Rfc8941DisplayString(usize),
+    ExpectedQuote(usize),
+    InvalidUtf8InDisplayString(usize),
+    InvalidDisplayStringCharacter(usize),
+    UnterminatedDisplayString(usize),
+
+    ExpectedStartOfKey(usize),
+}
+
+impl<E: std::error::Error> From<E> for Repr {
+    fn from(err: E) -> Self {
+        Self::Visit(err.to_string().into())
+    }
+}
+
+impl fmt::Display for Repr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (msg, index) = match *self {
+            Self::Visit(ref msg) => return f.write_str(msg),
+
+            Self::NaN => return f.write_str("NaN"),
+            Self::OutOfRange => return f.write_str("out of range"),
+
+            Self::Empty => return f.write_str("cannot be empty"),
+            Self::InvalidCharacter(i) => ("invalid character", i),
+
+            Self::TrailingCharactersAfterMember(i) => ("trailing characters after member", i),
+            Self::TrailingComma(i) => ("trailing comma", i),
+            Self::TrailingCharactersAfterParsedValue(i) => {
+                ("trailing characters after parsed value", i)
+            }
+
+            Self::ExpectedStartOfInnerList(i) => ("expected start of inner list", i),
+            Self::ExpectedInnerListDelimiter(i) => {
+                ("expected inner list delimiter (' ' or ')')", i)
+            }
+            Self::UnterminatedInnerList(i) => ("unterminated inner list", i),
+
+            Self::ExpectedStartOfBareItem(i) => ("expected start of bare item", i),
+
+            Self::ExpectedStartOfBoolean(i) => ("expected start of boolean ('?')", i),
+            Self::ExpectedBoolean(i) => ("expected boolean ('0' or '1')", i),
+
+            Self::ExpectedStartOfString(i) => (r#"expected start of string ('"')"#, i),
+            Self::InvalidStringCharacter(i) => ("invalid string character", i),
+            Self::UnterminatedString(i) => ("unterminated string", i),
+
+            Self::UnterminatedEscapeSequence(i) => ("unterminated escape sequence", i),
+            Self::InvalidEscapeSequence(i) => ("invalid escape sequence", i),
+
+            Self::ExpectedStartOfToken(i) => ("expected start of token", i),
+
+            Self::ExpectedStartOfByteSequence(i) => ("expected start of byte sequence (':')", i),
+            Self::UnterminatedByteSequence(i) => ("unterminated byte sequence", i),
+            Self::InvalidByteSequence(i) => ("invalid byte sequence", i),
+
+            Self::ExpectedDigit(i) => ("expected digit", i),
+            Self::TooManyDigits(i) => ("too many digits", i),
+            Self::TooManyDigitsBeforeDecimalPoint(i) => ("too many digits before decimal point", i),
+            Self::TooManyDigitsAfterDecimalPoint(i) => ("too many digits after decimal point", i),
+            Self::TrailingDecimalPoint(i) => ("trailing decimal point", i),
+
+            Self::ExpectedStartOfDate(i) => ("expected start of date ('@')", i),
+            Self::Rfc8941Date(i) => ("RFC 8941 does not support dates", i),
+            Self::NonIntegerDate(i) => ("date must be an integer number of seconds", i),
+
+            Self::ExpectedStartOfDisplayString(i) => ("expected start of display string ('%')", i),
+            Self::Rfc8941DisplayString(i) => ("RFC 8941 does not support display strings", i),
+            Self::ExpectedQuote(i) => (r#"expected '"'"#, i),
+            Self::InvalidUtf8InDisplayString(i) => ("invalid UTF-8 in display string", i),
+            Self::InvalidDisplayStringCharacter(i) => ("invalid display string character", i),
+            Self::UnterminatedDisplayString(i) => ("unterminated display string", i),
+
+            Self::ExpectedStartOfKey(i) => ("expected start of key ('a'-'z' or '*')", i),
+        };
+
+        write!(f, "{msg} at index {index}")
+    }
+}
 
 /// An error that can occur in this crate.
 ///
@@ -16,43 +143,18 @@ use std::fmt;
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Error {
-    msg: Cow<'static, str>,
-    index: Option<usize>,
+    repr: Repr,
 }
 
-impl Error {
-    pub(crate) fn new(msg: &'static str) -> Self {
-        Self {
-            msg: Cow::Borrowed(msg),
-            index: None,
-        }
-    }
-
-    pub(crate) fn with_index(msg: &'static str, index: usize) -> Self {
-        Self {
-            msg: Cow::Borrowed(msg),
-            index: Some(index),
-        }
-    }
-
-    pub(crate) fn out_of_range() -> Self {
-        Self::new("out of range")
-    }
-
-    pub(crate) fn custom(msg: impl fmt::Display) -> Self {
-        Self {
-            msg: Cow::Owned(msg.to_string()),
-            index: None,
-        }
+impl From<Repr> for Error {
+    fn from(repr: Repr) -> Self {
+        Self { repr }
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.index {
-            None => f.write_str(&self.msg),
-            Some(index) => write!(f, "{} at index {}", self.msg, index),
-        }
+        fmt::Display::fmt(&self.repr, f)
     }
 }
 
@@ -82,10 +184,11 @@ impl NonEmptyStringError {
 }
 
 impl From<NonEmptyStringError> for Error {
-    fn from(err: NonEmptyStringError) -> Error {
-        Error {
-            msg: Cow::Borrowed(err.msg()),
-            index: err.byte_index,
+    fn from(err: NonEmptyStringError) -> Self {
+        match err.byte_index {
+            None => Repr::Empty,
+            Some(index) => Repr::InvalidCharacter(index),
         }
+        .into()
     }
 }

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{Error, GenericBareItem};
+use crate::{error, Error, GenericBareItem};
 
 const RANGE_I64: std::ops::RangeInclusive<i64> = -999_999_999_999_999..=999_999_999_999_999;
 
@@ -79,7 +79,7 @@ macro_rules! impl_conversion {
             fn try_from(v: $t) -> Result<Integer, Error> {
                 match i64::try_from(v) {
                     Ok(v) if RANGE_I64.contains(&v) => Ok(Integer(v)),
-                    _ => Err(Error::out_of_range()),
+                    _ => Err(error::Repr::OutOfRange)?,
                 }
             }
         }
@@ -103,7 +103,7 @@ macro_rules! impl_conversion {
             type Error = Error;
 
             fn try_from(v: Integer) -> Result<$t, Error> {
-                v.0.try_into().map_err(|_| Error::out_of_range())
+                v.0.try_into().map_err(|_| error::Repr::OutOfRange.into())
             }
         }
     };

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -79,7 +79,7 @@ macro_rules! impl_conversion {
             fn try_from(v: $t) -> Result<Integer, Error> {
                 match i64::try_from(v) {
                     Ok(v) if RANGE_I64.contains(&v) => Ok(Integer(v)),
-                    _ => Err(error::Repr::OutOfRange)?,
+                    _ => Err(error::Repr::OutOfRange.into()),
                 }
             }
         }

--- a/src/string.rs
+++ b/src/string.rs
@@ -4,7 +4,7 @@ use std::{
     string::String as StdString,
 };
 
-use crate::Error;
+use crate::{error, Error};
 
 /// An owned structured field value [string].
 ///
@@ -32,8 +32,8 @@ struct StringError {
 }
 
 impl From<StringError> for Error {
-    fn from(err: StringError) -> Error {
-        Error::with_index("invalid character", err.byte_index)
+    fn from(err: StringError) -> Self {
+        error::Repr::InvalidCharacter(err.byte_index).into()
     }
 }
 

--- a/src/test_decimal.rs
+++ b/src/test_decimal.rs
@@ -1,4 +1,4 @@
-use crate::{Decimal, Error, Integer};
+use crate::{error, Decimal, Error, Integer};
 
 // Expect a floating point error less than the smallest allowed value of 0.001
 const ABSERR: f64 = 0.000_1_f64;
@@ -59,19 +59,19 @@ fn test_into_f64() {
 #[test]
 fn test_try_from_f64() {
     for (expected, input) in [
-        (Err(Error::new("NaN")), f64::NAN),
-        (Err(Error::out_of_range()), f64::INFINITY),
-        (Err(Error::out_of_range()), f64::NEG_INFINITY),
-        (Err(Error::out_of_range()), 2_f64.powi(65)),
-        (Err(Error::out_of_range()), -(2_f64.powi(65))),
-        (Err(Error::out_of_range()), -1_000_000_000_000.0),
-        (Err(Error::out_of_range()), 1_000_000_000_000.0),
+        (Err(error::Repr::NaN), f64::NAN),
+        (Err(error::Repr::OutOfRange), f64::INFINITY),
+        (Err(error::Repr::OutOfRange), f64::NEG_INFINITY),
+        (Err(error::Repr::OutOfRange), 2_f64.powi(65)),
+        (Err(error::Repr::OutOfRange), -(2_f64.powi(65))),
+        (Err(error::Repr::OutOfRange), -1_000_000_000_000.0),
+        (Err(error::Repr::OutOfRange), 1_000_000_000_000.0),
         (Ok(Decimal::MIN), -999_999_999_999.999),
         (Ok(Decimal::MIN), -999_999_999_999.999_1),
-        (Err(Error::out_of_range()), -999_999_999_999.999_5),
+        (Err(error::Repr::OutOfRange), -999_999_999_999.999_5),
         (Ok(Decimal::MAX), 999_999_999_999.999),
         (Ok(Decimal::MAX), 999_999_999_999.999_1),
-        (Err(Error::out_of_range()), 999_999_999_999.999_5),
+        (Err(error::Repr::OutOfRange), 999_999_999_999.999_5),
         (Ok(Decimal::ZERO), 0.0),
         (Ok(Decimal::ZERO), -0.0),
         (
@@ -99,6 +99,6 @@ fn test_try_from_f64() {
             -0.1236,
         ),
     ] {
-        assert_eq!(expected, Decimal::try_from(input));
+        assert_eq!(expected.map_err(Error::from), Decimal::try_from(input));
     }
 }


### PR DESCRIPTION
This simplifies testing, reduces the size of the Error type, and will make it easier to expose structured information about them in the future.