### PR TITLE
fix(cargo.toml): require `indexmap` `>=2.7`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.77"
 [dependencies]
 arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
 base64 = "0.22.1"
-indexmap = { version = "2", optional = true }
+indexmap = { version = "2.7", optional = true }
 ref-cast = "1.0.23"
 
 [dev-dependencies]


### PR DESCRIPTION
`sfv` uses `indexmap`'s `Entry::insert_entry`:

https://github.com/undef1nd/sfv/blob/f8973f53c0e78894ad0cdfa7b72f1aebbc4c6cfc/src/parsed.rs#L200-L203

`indexmap` [added support for `Entry::insert_entry` in `v2.7`](https://github.com/indexmap-rs/indexmap/blob/91dbcc55d2b6be52b7f99929aebb7204a6576189/RELEASES.md#270-2024-11-30).

Thus `sfv` needs to require `indexmap` `>=2.7`.

See sample failure with `<2.7` in https://github.com/mozilla/neqo/pull/2856.

//CC @larseggert