### PR TITLE
Update MSRV to 1.82

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -36,7 +36,7 @@ jobs:
           submodules: 'true'
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.77
+          toolchain: 1.82
           override: true
       - name: Build with MSRV
         run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ Implementation of RFC 8941 and RFC 9651."""
 repository = "https://github.com/undef1nd/sfv"
 keywords = ["http-header", "structured-header", ]
 exclude = ["tests/**", ".github/*", "benches/**", "fuzz/**"]
-rust-version = "1.77"
+rust-version = "1.82"
 
 [dependencies]
 arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }


### PR DESCRIPTION
Bump minimum Rust version to 1.82 for dependency compatibility.

Closes https://github.com/undef1nd/sfv/issues/216