### PR TITLE
Remove redundant String/StringRef validation in parser

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -319,10 +319,10 @@ assert_eq!(
                     return Ok(if output.is_empty() {
                         let slice = &self.input[start..end];
                         let output = std::str::from_utf8(slice).unwrap();
-                        Cow::Borrowed(StringRef::from_str(output).unwrap())
+                        Cow::Borrowed(StringRef::from_validated_str(output))
                     } else {
                         let output = StdString::from_utf8(output).unwrap();
-                        Cow::Owned(String::from_string(output).unwrap())
+                        Cow::Owned(String::from_validated_string(output))
                     });
                 }
                 0x00..=0x1f | 0x7f..=0xff => {

--- a/src/string.rs
+++ b/src/string.rs
@@ -67,6 +67,13 @@ impl StringRef {
         Ok(Self::cast(v))
     }
 
+    // Like `from_str`, but assumes that the contents of the string have already
+    // been validated as a string.
+    pub(crate) fn from_validated_str(v: &str) -> &Self {
+        debug_assert!(validate(v.as_bytes()).is_ok());
+        Self::cast(v)
+    }
+
     /// Creates a `&StringRef`.
     ///
     /// This method is intended to be called from `const` contexts in which the
@@ -144,6 +151,13 @@ impl String {
             Ok(()) => Ok(Self(v)),
             Err(err) => Err((err.into(), v)),
         }
+    }
+
+    // Like `from_string`, but assumes that the contents of the string have already
+    // been validated as a string.
+    pub(crate) fn from_validated_string(v: StdString) -> Self {
+        debug_assert!(validate(v.as_bytes()).is_ok());
+        Self(v)
     }
 }
 


### PR DESCRIPTION
Analogous to the existing optimization for KeyRef/TokenRef.