### PR TITLE
Remove redundant Integer/Decimal validation in parser

### DIFF
--- a/src/integer.rs
+++ b/src/integer.rs
@@ -46,6 +46,12 @@ impl Integer {
             panic!("out of range for Integer")
         }
     }
+
+    // Like `TryFrom`, but assumes that the range has already been validated.
+    pub(crate) fn from_validated_i64(v: i64) -> Self {
+        debug_assert!(RANGE_I64.contains(&v));
+        Self(v)
+    }
 }
 
 impl fmt::Display for Integer {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -472,7 +472,7 @@ assert_eq!(
                     self.next();
                     magnitude = magnitude * 10 + char_to_i64(c);
                 }
-                _ => return Ok(Num::Integer(Integer::try_from(sign * magnitude).unwrap())),
+                _ => return Ok(Num::Integer(Integer::from_validated_i64(sign * magnitude))),
             }
         }
 
@@ -495,7 +495,7 @@ assert_eq!(
             Err(error::Repr::TrailingDecimalPoint(self.index - 1))
         } else {
             Ok(Num::Decimal(Decimal::from_integer_scaled_1000(
-                Integer::try_from(sign * magnitude).unwrap(),
+                Integer::from_validated_i64(sign * magnitude),
             )))
         }
     }


### PR DESCRIPTION
Analogous to the existing optimization for KeyRef/TokenRef/StringRef.